### PR TITLE
Align order typings and harden recent orders retrieval

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -14,7 +14,7 @@
 <a href="https://discord.gg/G7Qnnhy" target="_blank"><img src="https://img.shields.io/badge/discord-online-brightgreen.svg" alt="Discord"/></a>
 <a href="https://opencollective.com/nest#backer" target="_blank"><img src="https://opencollective.com/nest/backers/badge.svg" alt="Backers on Open Collective" /></a>
 <a href="https://opencollective.com/nest#sponsor" target="_blank"><img src="https://opencollective.com/nest/sponsors/badge.svg" alt="Sponsors on Open Collective" /></a>
-  <a href="https://paypal.me/kamilmysliwiec" target="_blank"><img src="https://img.shields.io/badge/Donate-PayPal-ff3f59.svg" alt="Donate us"/></a>
+  <a href="https://paypal.me/kamilmysliwiec" target="_blank"><img src="https://img.shields.io/badge/Donate-PayPal-ff3f59.svg" alt="Donate to us"/></a>
     <a href="https://opencollective.com/nest#sponsor"  target="_blank"><img src="https://img.shields.io/badge/Support%20us-Open%20Collective-41B883.svg" alt="Support us"></a>
   <a href="https://twitter.com/nestframework" target="_blank"><img src="https://img.shields.io/twitter/follow/nestframework.svg?style=social&label=Follow" alt="Follow us on Twitter"></a>
 </p>

--- a/apps/api/src/orders/orders.service.ts
+++ b/apps/api/src/orders/orders.service.ts
@@ -120,9 +120,11 @@ export class OrdersService {
 
   async recent(limit = 10) {
     try {
+      const normalizedLimit = Number.isFinite(limit) ? Math.trunc(limit) : 10;
+      const take = Math.min(50, Math.max(1, normalizedLimit));
       return await this.prisma.order.findMany({
         orderBy: { createdAt: 'desc' },
-        take: limit,
+        take,
         include: { items: true },
       });
     } catch (e: unknown) {

--- a/apps/api/src/orders/types.ts
+++ b/apps/api/src/orders/types.ts
@@ -1,21 +1,24 @@
 export type Channel = 'web' | 'in_store' | 'ubereats';
-export type Fulfillment = 'pickup' | 'dine_in';
+export type FulfillmentType = 'pickup' | 'dine_in';
 
 export interface OrderItem {
+  id: string;
+  orderId: string;
   productId: string;
   qty: number;
-  options?: Record<string, unknown>;
+  unitPriceCents: number | null;
+  optionsJson: Record<string, unknown> | null;
 }
 
 export interface Order {
   id: string;
   createdAt: string;
-  channel: 'web' | 'in_store' | 'ubereats';
-  items: Array<{ productId: string; qty: number }>;
-  subtotal: number;
-  taxTotal: number;
-  total: number;
-  fulfillmentType: 'pickup' | 'dine_in';
+  channel: Channel;
+  items: OrderItem[];
+  subtotalCents: number;
+  taxCents: number;
+  totalCents: number;
+  fulfillmentType: FulfillmentType;
   pickupCode: string;
-  status: 'paid' | 'pending';
+  status: 'pending' | 'paid' | 'making' | 'ready' | 'completed';
 }

--- a/apps/api/test/app.e2e-spec.ts
+++ b/apps/api/test/app.e2e-spec.ts
@@ -25,4 +25,8 @@ describe('AppController (e2e)', () => {
   it('GET /api/health', async () => {
     await http.get('/api/health').expect(200).expect({ status: 'ok' });
   });
+
+  it('GET /api', async () => {
+    await http.get('/api').expect(200).expect({ ok: true });
+  });
 });


### PR DESCRIPTION
## Summary
- correct the README badge alt text grammar
- update shared order typings to reflect the API payload and clamp recent-order queries to a safe limit
- expand the e2e suite with a smoke test for the API root endpoint

## Testing
- npm test -- --runTestsByPath src/app.controller.spec.ts test/app.e2e-spec.ts
- npm run test:e2e -- --runTestsByPath test/app.e2e-spec.ts *(fails: missing DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68e32f27637c8324b71bd16b07c479f4