### PR TITLE
修复当日小结默认排除已取消/退款订单

### DIFF
--- a/apps/api/src/pos/pos-summary.service.ts
+++ b/apps/api/src/pos/pos-summary.service.ts
@@ -192,6 +192,7 @@ export class PosSummaryService {
     const where: Prisma.OrderWhereInput = {
       paidAt: { gte: start, lt: end },
       ...(fulfillmentFilter ? { fulfillmentType: fulfillmentFilter } : {}),
+      ...(statusFilter ? {} : { status: { not: 'refunded' } }),
     };
 
     const orders = (await this.prisma.order.findMany({
@@ -340,7 +341,12 @@ export class PosSummaryService {
         salesCents: salesCentsForOrder,
       };
 
-      if (statusFilter && row.statusBucket !== statusFilter) continue;
+      // 默认当日小结只统计有效收款订单；退款/取消订单仅在明确筛选时展示，避免关店结算重复计入。
+      if (statusFilter) {
+        if (row.statusBucket !== statusFilter) continue;
+      } else if (row.statusBucket !== 'paid') {
+        continue;
+      }
       if (paymentFilter && row.payment !== paymentFilter) continue;
 
       rows.push(row);


### PR DESCRIPTION
### Motivation
- 解决门店关店结算时已取消/退款订单仍被计入“当日小结”导致结算错误的问题。 

### Description
- 在 `apps/api/src/pos/pos-summary.service.ts` 的查询 `where` 中，当未指定状态筛选时默认排除 `refunded` 状态的订单。 
- 在组装行级数据时补充逻辑：若未显式传入 `status` 筛选，则只计入 `paid` bucket 的订单；传入 `refunded`/`void` 时仍可查看对应明细。 

### Testing
- 运行 `pnpm --filter api build`，构建通过。 
- 运行 `pnpm --filter api test -- --runInBand`，结果为 13 个测试套件中 12 个通过、1 个失败；失败套件为 `src/orders/orders.service.spec.ts`，失败原因为测试环境无法解析 `@shared/menu`（模块导入问题，与本次逻辑变更无关）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31cc7ca9e08327ae43f790b2cefa3d)