### PR TITLE
修复 POS 退/换菜时菜品选择不可单独操作的问题

### DIFF
--- a/apps/web/src/app/[locale]/store/pos/orders/page.tsx
+++ b/apps/web/src/app/[locale]/store/pos/orders/page.tsx
@@ -544,6 +544,7 @@ type OrderRecord = {
 };
 
 type OrderItemRecord = {
+  lineId: string;
   stableId: string;
   name: string;
   nameEn?: string | null;
@@ -703,14 +704,14 @@ function ActionContent({
               <div className="mt-2 space-y-2">
                 {order.items.map((item) => (
                   <label
-                    key={item.stableId}
+                    key={item.lineId}
                     className="flex items-center justify-between gap-3 rounded-lg border border-slate-700 bg-slate-950/40 px-3 py-2 text-[11px]"
                   >
                     <div className="flex items-center gap-2">
                       <input
                         type="checkbox"
-                        checked={selectedItemIds.includes(item.stableId)}
-                        onChange={() => onToggleItem(item.stableId)}
+                        checked={selectedItemIds.includes(item.lineId)}
+                        onChange={() => onToggleItem(item.lineId)}
                         className="h-3.5 w-3.5 rounded border-slate-500 bg-slate-900 text-emerald-400"
                       />
                       <div>
@@ -725,30 +726,30 @@ function ActionContent({
                     <span className="text-xs font-semibold text-slate-100">
                       {formatMoney(item.totalCents)}
                     </span>
-                    {selectedItemIds.includes(item.stableId) ? (
+                    {selectedItemIds.includes(item.lineId) ? (
                       <div className="ml-2 flex items-center gap-1">
                         <button
                           type="button"
                           onClick={(event) => {
                             event.preventDefault();
                             const nextQty =
-                              (selectedItemQtyMap[item.stableId] ?? 1) - 1;
-                            onItemQtyChange(item.stableId, nextQty);
+                              (selectedItemQtyMap[item.lineId] ?? 1) - 1;
+                            onItemQtyChange(item.lineId, nextQty);
                           }}
                           className="h-6 w-6 rounded border border-slate-600 text-xs"
                         >
                           -
                         </button>
                         <span className="w-8 text-center text-xs">
-                          {selectedItemQtyMap[item.stableId] ?? 1}
+                          {selectedItemQtyMap[item.lineId] ?? 1}
                         </span>
                         <button
                           type="button"
                           onClick={(event) => {
                             event.preventDefault();
                             const nextQty =
-                              (selectedItemQtyMap[item.stableId] ?? 1) + 1;
-                            onItemQtyChange(item.stableId, nextQty);
+                              (selectedItemQtyMap[item.lineId] ?? 1) + 1;
+                            onItemQtyChange(item.lineId, nextQty);
                           }}
                           className="h-6 w-6 rounded border border-slate-600 text-xs"
                         >
@@ -1091,9 +1092,10 @@ const mapOrder = useCallback(
       order.pickupCode?.trim() ||
       order.orderStableId;
 
-    const items = order.items.map((item) => {
+    const items = order.items.map((item, index) => {
       const unitPriceCents = item.unitPriceCents ?? 0;
       return {
+        lineId: `${item.productStableId}:${index}`,
         stableId: item.productStableId,
         name: pickItemName(item, locale),
         nameEn: item.nameEn ?? null,
@@ -1273,11 +1275,11 @@ const mapOrder = useCallback(
     const baseTax = selectedOrder.taxCents;
     const baseDelivery = selectedOrder.deliveryFeeCents;
     const selectedItems = selectedOrder.items
-      .filter((item) => selectedItemIds.includes(item.stableId))
+      .filter((item) => selectedItemIds.includes(item.lineId))
       .map((item) => {
         const qty = Math.max(
           1,
-          Math.min(item.qty, selectedItemQtyMap[item.stableId] ?? 1),
+          Math.min(item.qty, selectedItemQtyMap[item.lineId] ?? 1),
         );
         return {
           ...item,
@@ -1429,7 +1431,7 @@ const mapOrder = useCallback(
 
   const handleItemQtyChange = (id: string, qty: number) => {
     const maxQty =
-      selectedOrder?.items.find((item) => item.stableId === id)?.qty ?? 1;
+      selectedOrder?.items.find((item) => item.lineId === id)?.qty ?? 1;
     const boundedQty = Math.max(1, Math.min(maxQty, Math.round(qty)));
     setSelectedItemQtyMap((prev) => ({ ...prev, [id]: boundedQty }));
   };
@@ -1546,12 +1548,12 @@ const handleSubmit = () => {
   if (!canSubmit) return;
 
   const selectedItems = selectedOrder.items
-    .filter((item) => selectedItemIds.includes(item.stableId))
+    .filter((item) => selectedItemIds.includes(item.lineId))
     .map((item) => ({
       ...item,
       selectedQty: Math.max(
         1,
-        Math.min(item.qty, selectedItemQtyMap[item.stableId] ?? 1),
+        Math.min(item.qty, selectedItemQtyMap[item.lineId] ?? 1),
       ),
     }));
 


### PR DESCRIPTION
### Motivation
- 解决在门店 POS 界面进行退菜/换菜时，若订单中存在相同 `productStableId` 的多行菜品会被一起勾选或取消，无法对单独某一行进行更换/取消的缺陷。 
- 需要在 UI 层引入行级标识以区分同一菜品多行，且不改变后端对 `productStableId` / `stableId` 的语义。 

### Description
- 为订单行新增 UI 标识字段 `lineId`（格式为 ``${productStableId}:${index}``），并在 `mapOrder` 中生成该 `lineId`。
- 将退/换菜列表的行 `key`、checkbox 状态判断与数量控制从原来的 `stableId` 改为 `lineId`，并把相关事件处理器如 `onToggleItem`、`handleItemQtyChange` 等切换到使用 `lineId`。
- 将订单小结、选中项汇总与提交前的选中项集合改为基于 `lineId` 进行过滤与数量读取，提交到后端的 amendment items 仍保留使用 `productStableId`（后端 payload 语义不变）。

### Testing
- 运行构建：`pnpm --filter web build`，构建成功并生成静态/SSG 页面（通过）。
- 静态检查：`git diff --check`，未发现冲突或检查错误（通过）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31d20673f483278a1466282d21ef31)