### PR TITLE
Add expandable/collapsible optional option groups in options modal

### DIFF
--- a/apps/web/src/app/[locale]/page.tsx
+++ b/apps/web/src/app/[locale]/page.tsx
@@ -325,6 +325,9 @@ export default function LocalOrderPage() {
   const [selectedChildOptions, setSelectedChildOptions] = useState<
     Record<string, string[]>
   >({});
+  const [expandedOptionalGroups, setExpandedOptionalGroups] = useState<
+    Record<string, boolean>
+  >({});
 
   const entitlementItems = useMemo(
     () =>
@@ -461,6 +464,7 @@ export default function LocalOrderPage() {
     setActiveItem(null);
     setSelectedOptions({});
     setSelectedChildOptions({});
+    setExpandedOptionalGroups({});
     setSelectedQuantity(1);
     setSelectedDailySpecial(null);
   };
@@ -807,6 +811,11 @@ export default function LocalOrderPage() {
     const groupPath = [...basePath, buildGroupSegment(group, groupIndex)];
     const groupKey = buildPathKey(groupPath);
     const selectedCount = selectedOptions[groupKey]?.length ?? 0;
+    const isRequiredGroup = group.minSelect > 0;
+    const isExpanded =
+      isRequiredGroup ||
+      expandedOptionalGroups[groupKey] === true ||
+      selectedCount > 0;
     
     const requirementLabel = (() => {
         if (group.minSelect > 0 && group.maxSelect === 1) return locale === "zh" ? "必选 1 项" : "Required: 1";
@@ -818,18 +827,46 @@ export default function LocalOrderPage() {
 
     return (
         <div key={groupKey} className="space-y-3">
-            <div className="flex items-center justify-between gap-4">
+            <button
+              type="button"
+              onClick={() => {
+                if (isRequiredGroup) return;
+                setExpandedOptionalGroups((prev) => ({
+                  ...prev,
+                  [groupKey]: !prev[groupKey],
+                }));
+              }}
+              className={`flex w-full items-center justify-between gap-4 rounded-2xl text-left transition ${
+                isRequiredGroup
+                  ? "cursor-default"
+                  : "cursor-pointer hover:bg-slate-50"
+              }`}
+            >
             <div>
                 <h4 className="text-base font-semibold text-slate-900">
                 {locale === "zh" && group.template.nameZh ? group.template.nameZh : group.template.nameEn}
                 </h4>
                 <p className="text-xs text-slate-500">{requirementLabel}</p>
             </div>
-            <span className={`text-xs font-semibold ${group.minSelect > 0 && selectedCount < group.minSelect ? "text-rose-500" : "text-slate-400"}`}>
-                {locale === "zh" ? `已选 ${selectedCount}` : `${selectedCount} selected`}
+            <span className="flex items-center gap-2">
+                {!isRequiredGroup ? (
+                  <span className="rounded-full border border-slate-200 px-2 py-1 text-xs font-semibold text-slate-500">
+                    {isExpanded
+                      ? locale === "zh"
+                        ? "收起"
+                        : "Collapse"
+                      : locale === "zh"
+                        ? "点击展开"
+                        : "Expand"}
+                  </span>
+                ) : null}
+                <span className={`text-xs font-semibold ${group.minSelect > 0 && selectedCount < group.minSelect ? "text-rose-500" : "text-slate-400"}`}>
+                    {locale === "zh" ? `已选 ${selectedCount}` : `${selectedCount} selected`}
+                </span>
             </span>
-            </div>
+            </button>
 
+            {isExpanded ? (
             <div className="grid gap-2 md:grid-cols-2">
             {group.options
               .filter(
@@ -947,6 +984,7 @@ export default function LocalOrderPage() {
                 );
             })}
             </div>
+            ) : null}
         </div>
     );
   };


### PR DESCRIPTION
### Motivation
- Reduce visual clutter in the item options modal by letting optional option groups be collapsed or expanded, while keeping required groups always visible.
- Persist per-group expansion state while the modal is open and reset it when the modal is closed.

### Description
- Added `expandedOptionalGroups` state to track expansion for each option group and clear it in `closeOptionsModal` by calling `setExpandedOptionalGroups({})`.
- Updated `renderOptionGroup` to derive `isRequiredGroup` and `isExpanded` and to wrap the group header in a clickable `button` that toggles expansion for optional groups using `setExpandedOptionalGroups`.
- Show an expand/collapse label and keep required groups non-clickable, and only render the group options grid when `isExpanded` is true.
- Maintained existing selection and nested group rendering logic while adjusting some UI CSS classes for the interactive header.

### Testing
- Ran TypeScript type-check and local development build (`next build`) with no type errors.
- Executed the existing automated test suite and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3823f98bc48327b799feede3159382)