### PR TITLE
Improve Apple Pay event parsing, logging, and error handling

### DIFF
--- a/apps/web/src/app/[locale]/wallet/apple-pay/page.tsx
+++ b/apps/web/src/app/[locale]/wallet/apple-pay/page.tsx
@@ -45,6 +45,41 @@ type CloverInstance = {
 };
 type CloverConstructor = new (key?: string, options?: { merchantId?: string }) => CloverInstance;
 
+function getApplePayEventDetail(event: Event): Record<string, unknown> | undefined {
+  if (!(event instanceof CustomEvent)) return undefined;
+  return event.detail && typeof event.detail === "object" && !Array.isArray(event.detail) ? (event.detail as Record<string, unknown>) : undefined;
+}
+
+function getApplePayToken(detail: Record<string, unknown> | undefined): string | undefined {
+  const misspelledToken = detail?.tokenRecieved;
+  if (misspelledToken && typeof misspelledToken === "object" && "id" in misspelledToken && typeof (misspelledToken as { id?: unknown }).id === "string") {
+    return (misspelledToken as { id: string }).id;
+  }
+
+  const correctedToken = detail?.tokenReceived;
+  if (correctedToken && typeof correctedToken === "object" && "id" in correctedToken && typeof (correctedToken as { id?: unknown }).id === "string") {
+    return (correctedToken as { id: string }).id;
+  }
+
+  return undefined;
+}
+
+function buildApplePayEventLog(detail: Record<string, unknown> | undefined) {
+  return {
+    hasDetail: !!detail,
+    detailKeys: detail ? Object.keys(detail) : [],
+    hasTokenRecieved: !!detail?.tokenRecieved,
+    hasTokenReceived: !!detail?.tokenReceived,
+    status: typeof detail?.status === "string" ? detail.status : undefined,
+  };
+}
+
+function getApplePayMissingTokenMessage(locale: Locale) {
+  return locale === "zh"
+    ? "Apple Pay 未返回支付令牌，请关闭支付窗口后重试或改用其他支付方式。"
+    : "Apple Pay did not return a payment token. Please close the payment sheet and try again or use another payment method.";
+}
+
 function toSafeErrorLog(error: unknown) {
   if (error instanceof ApiError) return { name: error.name, message: error.message, status: error.status };
   if (error instanceof Error) return { name: error.name, message: error.message };
@@ -208,14 +243,18 @@ export default function ApplePayWalletPage() {
     void init();
 
     const onPaymentMethod = async (event: Event) => {
-      const detail = event instanceof CustomEvent ? event.detail : undefined;
-      const token =
-        (typeof detail === "object" && detail && "tokenRecieved" in detail && typeof (detail as { tokenRecieved?: { id?: unknown } }).tokenRecieved?.id === "string"
-          ? (detail as { tokenRecieved: { id: string } }).tokenRecieved.id : undefined) ??
-        (typeof detail === "object" && detail && "tokenReceived" in detail && typeof (detail as { tokenReceived?: { id?: unknown } }).tokenReceived?.id === "string"
-          ? (detail as { tokenReceived: { id: string } }).tokenReceived.id : undefined);
-      if (!token) return;
+      const detail = getApplePayEventDetail(event);
+      console.debug("[AP][paymentMethod raw]", buildApplePayEventLog(detail));
+      const token = getApplePayToken(detail);
+      if (!token) {
+        console.error("[AP][token-missing]", buildApplePayEventLog(detail));
+        cloverRef.current?.updateApplePaymentStatus("failed");
+        setError(getApplePayMissingTokenMessage(locale));
+        return;
+      }
       if (sessionExpired) {
+        console.warn("[AP][session-expired-before-submit]", { sessionId: ctx.sessionId });
+        cloverRef.current?.updateApplePaymentStatus("failed");
         setError(locale === "zh" ? "支付会话已过期，请返回结算页重新发起支付。" : "Payment session expired. Please go back to checkout and restart payment.");
         return;
       }
@@ -257,10 +296,22 @@ export default function ApplePayWalletPage() {
       }
     };
 
+    const onPaymentMethodEnd = (event: Event) => {
+      const detail = getApplePayEventDetail(event);
+      console.debug("[AP][paymentMethodEnd]", buildApplePayEventLog(detail));
+      const status = typeof detail?.status === "string" ? detail.status : undefined;
+      if (status === "session_cancelled") {
+        setError(locale === "zh" ? "Apple Pay 已取消，请重试或改用其他支付方式。" : "Apple Pay was cancelled. Please try again or use another payment method.");
+        submittedTokenRef.current = null;
+      }
+    };
+
     window.addEventListener("paymentMethod", onPaymentMethod);
+    window.addEventListener("paymentMethodEnd", onPaymentMethodEnd);
     return () => {
       cancelled = true;
       window.removeEventListener("paymentMethod", onPaymentMethod);
+      window.removeEventListener("paymentMethodEnd", onPaymentMethodEnd);
       applePayRef.current?.destroy?.();
       applePayRef.current = null;
       cloverRef.current = null;


### PR DESCRIPTION
### Motivation

- Make Apple Pay event handling more robust against malformed or misspelled event payloads and provide clearer failure messaging. 

### Description

- Add `getApplePayEventDetail` and `getApplePayToken` to safely extract event details and support both `tokenRecieved` (misspelled) and `tokenReceived` keys. 
- Add `buildApplePayEventLog` and extra `console.debug`/`console.error` logs to capture event shapes and token problems for easier debugging. 
- Fail fast when a token is missing by calling `updateApplePaymentStatus("failed")` and showing a localized error via `getApplePayMissingTokenMessage`. 
- Add `onPaymentMethodEnd` listener to surface `session_cancelled` events with a localized message and wire up proper event listener cleanup. 

### Testing

- Ran the TypeScript build (`tsc`) which completed successfully. 
- Executed the project's automated unit tests (`yarn test`) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a382a3e51ec83278554757325783ab0)