### PR TITLE
Fetch fewer POS orders and show newest orders first

### DIFF
--- a/apps/web/src/app/[locale]/store/pos/orders/page.tsx
+++ b/apps/web/src/app/[locale]/store/pos/orders/page.tsx
@@ -561,10 +561,10 @@ type SwapSelection = {
   quantity: number;
 };
 
-function compareOrderCreatedAtAsc(a: OrderRecord, b: OrderRecord) {
+function compareOrderCreatedAtDesc(a: OrderRecord, b: OrderRecord) {
   const aTime = parseBackendDate(a.createdAt).getTime();
   const bTime = parseBackendDate(b.createdAt).getTime();
-  return aTime - bTime;
+  return bTime - aTime;
 }
 
 type ActionSummary = {
@@ -1138,7 +1138,7 @@ const mapOrder = useCallback(
         setErrorMessage(null);
         const [configRes, data] = await Promise.all([
           apiFetch<BusinessConfigLite>("/admin/business/config").catch(() => null),
-          fetchRecentOrders<BackendOrder[]>(200),
+          fetchRecentOrders<BackendOrder[]>(30),
         ]);
 
         if (cancelled) return;
@@ -1264,7 +1264,7 @@ const mapOrder = useCallback(
         }
         return true;
       })
-      .sort(compareOrderCreatedAtAsc);
+      .sort(compareOrderCreatedAtDesc);
   }, [filters, orders, storeTimezone, todayYmd]);
 
   const summary = useMemo(() => {


### PR DESCRIPTION
### Motivation
- Reduce the number of recent POS orders fetched to lower load and ensure the order list displays newest orders first.

### Description
- Change the recent orders fetch from `fetchRecentOrders<BackendOrder[]>(200)` to `fetchRecentOrders<BackendOrder[]>(30)` and invert the sort order by replacing `compareOrderCreatedAtAsc` with `compareOrderCreatedAtDesc` which returns `bTime - aTime`, then use the new comparator in the `.sort()` call.

### Testing
- Ran a TypeScript build (`yarn build`), linter (`yarn lint`), and test suite (`yarn test`), and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a383bf366bc8327adbc4b7d2e38f598)