### PR TITLE
Reports: correctly aggregate Top 10 items by real product stableId and split combo choices

### DIFF
--- a/apps/api/src/reports/reports.service.spec.ts
+++ b/apps/api/src/reports/reports.service.spec.ts
@@ -1,0 +1,183 @@
+import { ReportsService } from './reports.service';
+
+const baseOptionGroup = (choices: Array<{ stableId: string }>) => [
+  {
+    templateGroupStableId: 'group_combo',
+    nameEn: 'Combo choices',
+    nameZh: '套餐选项',
+    minSelect: 0,
+    maxSelect: null,
+    sortOrder: 0,
+    choices: choices.map((choice, index) => ({
+      stableId: choice.stableId,
+      templateGroupStableId: 'group_combo',
+      nameEn: choice.stableId,
+      nameZh: null,
+      priceDeltaCents: 0,
+      sortOrder: index,
+    })),
+  },
+];
+
+describe('ReportsService', () => {
+  const createService = (orderItems: unknown[]) => {
+    const prisma = {
+      order: {
+        aggregate: jest.fn().mockResolvedValue({
+          _sum: {
+            totalCents: 0,
+            subtotalCents: 0,
+            taxCents: 0,
+            deliveryFeeCents: 0,
+          },
+          _count: { id: 0 },
+        }),
+        groupBy: jest.fn().mockResolvedValue([]),
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+      orderItem: {
+        findMany: jest.fn().mockResolvedValue(orderItems),
+      },
+      menuOptionTemplateChoice: {
+        findMany: jest.fn().mockResolvedValue([
+          { stableId: 'choice_chicken', targetItemStableId: 'item_chicken' },
+          { stableId: 'choice_beef', targetItemStableId: 'item_beef' },
+        ]),
+      },
+      menuItem: {
+        findMany: jest.fn().mockResolvedValue([
+          { stableId: 'item_chicken', nameEn: 'Chicken', nameZh: '鸡肉' },
+          { stableId: 'item_beef', nameEn: 'Beef', nameZh: '牛肉' },
+        ]),
+      },
+    };
+
+    const service = new ReportsService(prisma as never);
+    return { service, prisma };
+  };
+
+  it('普通单品按自身计数', async () => {
+    const { service } = createService([
+      {
+        qty: 3,
+        productStableId: 'item_noodle',
+        displayName: 'Noodle',
+        nameEn: 'Noodle',
+        nameZh: '面',
+        optionsJson: null,
+      },
+    ]);
+
+    const report = await service.getReport({
+      from: '2026-01-01',
+      to: '2026-01-01',
+    });
+
+    expect(report.topItems).toEqual([{ name: 'Noodle', quantity: 3 }]);
+  });
+
+  it('套餐订单行不作为独立商品出现，且套餐内菜品按套餐数量累加', async () => {
+    const { service } = createService([
+      {
+        qty: 2,
+        productStableId: 'combo_lunch',
+        displayName: 'Lunch Combo',
+        nameEn: 'Lunch Combo',
+        nameZh: '午餐套餐',
+        optionsJson: baseOptionGroup([{ stableId: 'choice_chicken' }]),
+      },
+    ]);
+
+    const report = await service.getReport({
+      from: '2026-01-01',
+      to: '2026-01-01',
+    });
+
+    expect(report.topItems).toEqual([{ name: '鸡肉', quantity: 2 }]);
+    expect(report.topItems).not.toContainEqual({
+      name: 'Lunch Combo',
+      quantity: 2,
+    });
+  });
+
+  it('同一套餐内重复目标菜品按出现次数乘以套餐数量累加', async () => {
+    const { service } = createService([
+      {
+        qty: 2,
+        productStableId: 'combo_double',
+        displayName: 'Double Combo',
+        nameEn: 'Double Combo',
+        nameZh: '双拼套餐',
+        optionsJson: baseOptionGroup([
+          { stableId: 'choice_chicken' },
+          { stableId: 'choice_chicken' },
+          { stableId: 'choice_beef' },
+        ]),
+      },
+    ]);
+
+    const report = await service.getReport({
+      from: '2026-01-01',
+      to: '2026-01-01',
+    });
+
+    expect(report.topItems).toEqual([
+      { name: '鸡肉', quantity: 4 },
+      { name: '牛肉', quantity: 2 },
+    ]);
+  });
+
+  it('没有可拆分选项的订单项按原订单行回退统计', async () => {
+    const { service } = createService([
+      {
+        qty: 5,
+        productStableId: 'combo_unknown',
+        displayName: 'Unknown Combo',
+        nameEn: 'Unknown Combo',
+        nameZh: '未知套餐',
+        optionsJson: baseOptionGroup([{ stableId: 'choice_without_target' }]),
+      },
+    ]);
+
+    const report = await service.getReport({
+      from: '2026-01-01',
+      to: '2026-01-01',
+    });
+
+    expect(report.topItems).toEqual([{ name: 'Unknown Combo', quantity: 5 }]);
+  });
+
+  it('批量查询选项和目标菜品，避免按订单项逐条查询', async () => {
+    const { service, prisma } = createService([
+      {
+        qty: 1,
+        productStableId: 'combo_a',
+        displayName: 'Combo A',
+        nameEn: 'Combo A',
+        nameZh: null,
+        optionsJson: baseOptionGroup([{ stableId: 'choice_chicken' }]),
+      },
+      {
+        qty: 1,
+        productStableId: 'combo_b',
+        displayName: 'Combo B',
+        nameEn: 'Combo B',
+        nameZh: null,
+        optionsJson: baseOptionGroup([
+          { stableId: 'choice_chicken' },
+          { stableId: 'choice_beef' },
+        ]),
+      },
+    ]);
+
+    await service.getReport({ from: '2026-01-01', to: '2026-01-01' });
+
+    expect(prisma.menuOptionTemplateChoice.findMany).toHaveBeenCalledTimes(1);
+    expect(prisma.menuOptionTemplateChoice.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { stableId: { in: ['choice_chicken', 'choice_beef'] } },
+      }),
+    );
+    expect(prisma.menuItem.findMany).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/reports/reports.service.ts
+++ b/apps/api/src/reports/reports.service.ts
@@ -1,7 +1,7 @@
 // apps/api/src/reports/reports.service.ts
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
-import { OrderStatus } from '@prisma/client';
+import { OrderStatus, Prisma } from '@prisma/client';
 import { DateTime } from 'luxon';
 
 interface ReportQueryDto {
@@ -9,9 +9,148 @@ interface ReportQueryDto {
   to?: string;
 }
 
+type ReportOrderItem = {
+  qty: number;
+  productStableId: string;
+  displayName: string | null;
+  nameEn: string | null;
+  nameZh: string | null;
+  optionsJson: Prisma.JsonValue | null;
+};
+
+type TopItemAggregate = {
+  name: string;
+  quantity: number;
+};
+
 @Injectable()
 export class ReportsService {
   constructor(private readonly prisma: PrismaService) {}
+
+  private async buildTopItems(orderItems: ReportOrderItem[]) {
+    const selectedChoiceStableIds = Array.from(
+      new Set(orderItems.flatMap((item) => this.extractChoiceStableIds(item))),
+    );
+
+    const choices = selectedChoiceStableIds.length
+      ? await this.prisma.menuOptionTemplateChoice.findMany({
+          where: { stableId: { in: selectedChoiceStableIds } },
+          select: { stableId: true, targetItemStableId: true },
+        })
+      : [];
+
+    const choiceTargetByStableId = new Map(
+      choices
+        .filter((choice) => choice.targetItemStableId)
+        .map((choice) => [
+          choice.stableId,
+          choice.targetItemStableId as string,
+        ]),
+    );
+
+    const targetItemStableIds = Array.from(
+      new Set(choiceTargetByStableId.values()),
+    );
+    const targetItems = targetItemStableIds.length
+      ? await this.prisma.menuItem.findMany({
+          where: { stableId: { in: targetItemStableIds }, deletedAt: null },
+          select: { stableId: true, nameEn: true, nameZh: true },
+        })
+      : [];
+
+    const targetNameByStableId = new Map(
+      targetItems.map((item) => [
+        item.stableId,
+        this.resolveItemName({
+          productStableId: item.stableId,
+          displayName: null,
+          nameEn: item.nameEn,
+          nameZh: item.nameZh,
+        }),
+      ]),
+    );
+
+    const aggregate = new Map<string, TopItemAggregate>();
+    const addItem = (key: string, name: string, quantity: number) => {
+      const current = aggregate.get(key);
+      aggregate.set(key, {
+        name: current?.name ?? name,
+        quantity: (current?.quantity ?? 0) + quantity,
+      });
+    };
+
+    for (const orderItem of orderItems) {
+      const targetStableIds = this.extractChoiceStableIds(orderItem)
+        .map((choiceStableId) => choiceTargetByStableId.get(choiceStableId))
+        .filter((stableId): stableId is string => Boolean(stableId));
+
+      if (targetStableIds.length > 0) {
+        for (const targetStableId of targetStableIds) {
+          addItem(
+            targetStableId,
+            targetNameByStableId.get(targetStableId) ?? targetStableId,
+            orderItem.qty,
+          );
+        }
+        continue;
+      }
+
+      addItem(
+        orderItem.productStableId,
+        this.resolveItemName(orderItem),
+        orderItem.qty,
+      );
+    }
+
+    return Array.from(aggregate.values())
+      .sort((a, b) => b.quantity - a.quantity)
+      .slice(0, 10);
+  }
+
+  private extractChoiceStableIds(
+    orderItem: Pick<ReportOrderItem, 'optionsJson'>,
+  ) {
+    if (!Array.isArray(orderItem.optionsJson)) {
+      return [];
+    }
+
+    const stableIds: string[] = [];
+    for (const group of orderItem.optionsJson) {
+      if (!group || typeof group !== 'object' || !('choices' in group)) {
+        continue;
+      }
+      const choices = (group as { choices?: unknown }).choices;
+      if (!Array.isArray(choices)) {
+        continue;
+      }
+      for (const choice of choices) {
+        if (!choice || typeof choice !== 'object' || !('stableId' in choice)) {
+          continue;
+        }
+        const stableId = (choice as { stableId?: unknown }).stableId;
+        if (typeof stableId === 'string' && stableId.trim().length > 0) {
+          stableIds.push(stableId);
+        }
+      }
+    }
+
+    return stableIds;
+  }
+
+  private resolveItemName(
+    item: Pick<
+      ReportOrderItem,
+      'productStableId' | 'displayName' | 'nameEn' | 'nameZh'
+    >,
+  ) {
+    return (
+      item.displayName ||
+      item.nameZh ||
+      item.nameEn ||
+      item.productStableId ||
+      '未知商品'
+    );
+  }
 
   async getReport(query: ReportQueryDto) {
     // 1. 确定时间范围 (默认为多伦多时间的一整天)
@@ -113,26 +252,23 @@ export class ReportsService {
       .sort((a, b) => a.date.localeCompare(b.date));
 
     // 8. 统计畅销单品 Top 10
-    const topItemsRaw = await this.prisma.orderItem.groupBy({
-      by: ['displayName'],
+    // 套餐会把选中的具体菜品快照写入 optionsJson，这里先取出订单项，
+    // 再在内存中按真实菜品 stableId 聚合，避免用 displayName 合并导致重名/语言问题。
+    const orderItems = await this.prisma.orderItem.findMany({
       where: {
         order: whereCondition,
       },
-      _sum: {
+      select: {
         qty: true,
+        productStableId: true,
+        displayName: true,
+        nameEn: true,
+        nameZh: true,
+        optionsJson: true,
       },
-      orderBy: {
-        _sum: {
-          qty: 'desc',
-        },
-      },
-      take: 10,
     });
 
-    const topItems = topItemsRaw.map((item) => ({
-      name: item.displayName || '未知商品',
-      quantity: item._sum.qty ?? 0,
-    }));
+    const topItems = await this.buildTopItems(orderItems);
 
     // 9. 计算最终结果
     const totalCents = aggregations._sum.totalCents ?? 0;


### PR DESCRIPTION
### Motivation
- 纠正报表中畅销单品统计，避免以 `displayName` 合并导致中英文/重名误计并支持套餐拆分。 
- 避免对每个订单项逐条查询造成 N+1，改为批量解析并关联模板选择与目标菜品。 

### Description
- 用 `prisma.orderItem.findMany(...)` 读取有效订单范围内的订单项，包含 `qty`, `productStableId`, 名称字段和 `optionsJson`，替代原先的 `groupBy` 聚合。 
- 新增 `buildTopItems` 聚合函数：解析 `optionsJson` 中的 choice `stableId`，批量查询 `MenuOptionTemplateChoice.targetItemStableId` 和目标 `MenuItem`，并在内存中按真实菜品 `stableId` 聚合数量。 
- 实现拆分规则：若选项映射到 `targetItemStableId`，按目标菜品累计（出现次数乘以订单行 `qty`），且不把套餐行本身计入 Top Items；若无可拆分目标菜品则回退按原订单行统计。 
- 保持返回契约不变，仍返回 `topItems: Array<{ name: string; quantity: number }>`，并添加辅助函数 `extractChoiceStableIds` 和 `resolveItemName`。 
- 新增单元测试 `apps/api/src/reports/reports.service.spec.ts` 覆盖普通单品、套餐拆分、重复选项累加、不可拆分回退、以及批量查询避免 N+1 场景。 

### Testing
- 运行 `pnpm --filter api test -- reports.service.spec.ts --runInBand`，相关测试共 5 条全部通过（5 passed）。 
- 运行 `pnpm --filter api exec prisma generate`（在 `pretest` 步骤中被执行）成功生成 Prisma 客户端。 
- 对改动文件执行了 ESLint/格式化检查（`prettier`/`eslint` 在工作流中运行），未发现阻塞性错误。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a383ec9d78c83279ac55ef4faf71d5a)