### PR TITLE
修复 Apple Pay 页面重复声明的 helper 函数

### DIFF
--- a/apps/web/src/app/[locale]/wallet/apple-pay/page.tsx
+++ b/apps/web/src/app/[locale]/wallet/apple-pay/page.tsx
@@ -111,41 +111,6 @@ function getApplePayMissingTokenMessage(locale: Locale) {
     : "Apple Pay did not return a payment token. Please close the payment sheet and try again or use another payment method.";
 }
 
-function getApplePayEventDetail(event: Event): Record<string, unknown> | undefined {
-  if (!(event instanceof CustomEvent)) return undefined;
-  return event.detail && typeof event.detail === "object" && !Array.isArray(event.detail) ? (event.detail as Record<string, unknown>) : undefined;
-}
-
-function getApplePayToken(detail: Record<string, unknown> | undefined): string | undefined {
-  const misspelledToken = detail?.tokenRecieved;
-  if (misspelledToken && typeof misspelledToken === "object" && "id" in misspelledToken && typeof (misspelledToken as { id?: unknown }).id === "string") {
-    return (misspelledToken as { id: string }).id;
-  }
-
-  const correctedToken = detail?.tokenReceived;
-  if (correctedToken && typeof correctedToken === "object" && "id" in correctedToken && typeof (correctedToken as { id?: unknown }).id === "string") {
-    return (correctedToken as { id: string }).id;
-  }
-
-  return undefined;
-}
-
-function buildApplePayEventLog(detail: Record<string, unknown> | undefined) {
-  return {
-    hasDetail: !!detail,
-    detailKeys: detail ? Object.keys(detail) : [],
-    hasTokenRecieved: !!detail?.tokenRecieved,
-    hasTokenReceived: !!detail?.tokenReceived,
-    status: typeof detail?.status === "string" ? detail.status : undefined,
-  };
-}
-
-function getApplePayMissingTokenMessage(locale: Locale) {
-  return locale === "zh"
-    ? "Apple Pay 未返回支付令牌，请关闭支付窗口后重试或改用其他支付方式。"
-    : "Apple Pay did not return a payment token. Please close the payment sheet and try again or use another payment method.";
-}
-
 function toSafeErrorLog(error: unknown) {
   if (error instanceof ApiError) return { name: error.name, message: error.message, status: error.status };
   if (error instanceof Error) return { name: error.name, message: error.message };


### PR DESCRIPTION
### Motivation
- Turbopack 构建报错提示若干函数在 `apps/web/src/app/[locale]/wallet/apple-pay/page.tsx` 中“被多次定义”，导致生产构建失败。 

### Description
- 从 `apps/web/src/app/[locale]/wallet/apple-pay/page.tsx` 中移除了重复的 helper 函数声明，保留单一的 `getApplePayEventDetail`、`getApplePayToken`、`buildApplePayEventLog` 和 `getApplePayMissingTokenMessage` 定义。 
- 清理了重复代码块并修复了由重复声明引发的命名冲突，保持其行为不变。 
- 仅修改了上述页面文件的内容，没有引入新依赖或更改其它配置。 

### Testing
- 运行 `pnpm --filter web build`，构建成功（Next.js/Turbopack 完成静态页面生成且未再出现多重定义错误）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c4588f5e483278ee09394560c81c9)