### PR TITLE
Fix stale Apple Pay initialization errors

### DIFF
--- a/apps/web/src/app/[locale]/wallet/apple-pay/page.tsx
+++ b/apps/web/src/app/[locale]/wallet/apple-pay/page.tsx
@@ -182,6 +182,8 @@ export default function ApplePayWalletPage() {
   const cloverRef = useRef<CloverInstance | null>(null);
   const applePayRef = useRef<CloverElementInstance | null>(null);
   const submittedTokenRef = useRef<string | null>(null);
+  const initRunIdRef = useRef(0);
+  const sessionExpiredRef = useRef(false);
 
   const currencyFormatter = useMemo(() => new Intl.NumberFormat(locale === "zh" ? "zh-Hans-CA" : "en-CA", {
     style: "currency", currency: HOSTED_CHECKOUT_CURRENCY, minimumFractionDigits: 2, maximumFractionDigits: 2,
@@ -225,6 +227,10 @@ export default function ApplePayWalletPage() {
   }, [locale, searchParams]);
 
   useEffect(() => {
+    sessionExpiredRef.current = sessionExpired;
+  }, [sessionExpired]);
+
+  useEffect(() => {
     if (!ctx) return;
     const tick = () => setRemainingMs(getRemainingMs(ctx.pricingTokenExpiresAt));
     tick();
@@ -255,12 +261,15 @@ export default function ApplePayWalletPage() {
     }
 
     let cancelled = false;
+    const initRunId = initRunIdRef.current + 1;
+    initRunIdRef.current = initRunId;
+    const isCurrentInit = () => !cancelled && initRunIdRef.current === initRunId;
     const init = async () => {
       try {
         console.debug("[AP][init] load-script:start", { sdkUrl });
         await loadScript(sdkUrl);
         console.debug("[AP][init] load-script:done", { sdkUrl });
-        if (cancelled) return;
+        if (!isCurrentInit()) return;
         const Clover = (window as ApplePayWindow).Clover;
         console.debug("[AP][init] clover-global", { hasClover: !!Clover });
         if (!Clover) throw new Error("Clover SDK not available");
@@ -314,9 +323,14 @@ export default function ApplePayWalletPage() {
         });
         host.innerHTML = "";
         applePay.mount("#clover-apple-pay");
+        if (!isCurrentInit()) {
+          applePay.destroy?.();
+          return;
+        }
         console.debug("[AP][init] apple-button:mounted", { sessionId: ctx.sessionId });
         applePayRef.current = applePay;
       } catch (err) {
+        if (!isCurrentInit()) return;
         console.error("[AP][session] init error", {
           ...toSafeErrorLog(err),
           sessionId: ctx.sessionId,
@@ -341,7 +355,7 @@ export default function ApplePayWalletPage() {
         setError(getApplePayMissingTokenMessage(locale));
         return;
       }
-      if (sessionExpired) {
+      if (sessionExpiredRef.current) {
         console.warn("[AP][session-expired-before-submit]", { sessionId: ctx.sessionId });
         cloverRef.current?.updateApplePaymentStatus("failed");
         setError(locale === "zh" ? "支付会话已过期，请返回结算页重新发起支付。" : "Payment session expired. Please go back to checkout and restart payment.");
@@ -401,12 +415,14 @@ export default function ApplePayWalletPage() {
       cancelled = true;
       window.removeEventListener("paymentMethod", onPaymentMethod);
       window.removeEventListener("paymentMethodEnd", onPaymentMethodEnd);
-      applePayRef.current?.destroy?.();
-      applePayRef.current = null;
-      cloverRef.current = null;
-      submittedTokenRef.current = null;
+      if (initRunIdRef.current === initRunId) {
+        applePayRef.current?.destroy?.();
+        applePayRef.current = null;
+        cloverRef.current = null;
+        submittedTokenRef.current = null;
+      }
     };
-  }, [ctx, locale, router, sessionExpired]);
+  }, [ctx, locale, router]);
 
   return (
     <main className="mx-auto flex min-h-screen w-full max-w-lg flex-col px-4 py-10">


### PR DESCRIPTION
### Motivation
- 修复 Apple Pay 初始化过程中的异步竞态，避免已取消或过期的初始化流程在新的按钮已挂载后仍然写入“Apple Pay 初始化失败”并触发重复错误提示。 

### Description
- 在 `apps/web/src/app/[locale]/wallet/apple-pay/page.tsx` 中新增 `initRunIdRef` 用于为每次初始化分配 run id 并通过 `isCurrentInit()` 判断是否为当前有效初始化。 
- 新增 `sessionExpiredRef` 以在事件回调中读取会话过期状态，避免因倒计时状态变化导致初始化 effect 重新注册或重复初始化。 
- 在异步初始化流程中和挂载后加入对 `isCurrentInit()` 的检查，若不是当前 run 则销毁新创建的 element 或直接忽略错误，从而避免过期流程覆盖新挂载状态。 
- 清理逻辑限定为仅在对应 run id 相同时才销毁 `applePayRef` / `cloverRef` / `submittedTokenRef`，并从 effect 依赖中移除 `sessionExpired`，以减少不必要的重新初始化。 

### Testing
- 运行了 `pnpm --filter web lint`，ESLint 报告 `✔ No ESLint warnings or errors`，测试通过。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c4c8525f08327b3a3e99b2ca63611)