### PR TITLE
将 Apple Pay 会话取消视为可重试错误

### DIFF
--- a/apps/web/src/app/[locale]/wallet/apple-pay/page.tsx
+++ b/apps/web/src/app/[locale]/wallet/apple-pay/page.tsx
@@ -563,6 +563,12 @@ export default function ApplePayWalletPage() {
             capability: getApplePayCapabilityLog(),
           });
           cloverRef.current?.updateApplePaymentStatus("failed");
+          const status = typeof detail?.status === "string" ? detail.status : undefined;
+          if (status === "session_cancelled") {
+            setError(locale === "zh" ? "Apple Pay 会话已取消或超时，请重试或改用其他支付方式。" : "Apple Pay was cancelled or timed out. Please try again or use another payment method.");
+            submittedTokenRef.current = null;
+            return;
+          }
           setInitError(buildApplePayElementErrorMessage(locale, detail));
         });
         host.innerHTML = "";


### PR DESCRIPTION
### Motivation
- 在 Apple Pay element 的 `paymentMethodEnd` 事件中区分 `detail.status`，将 `session_cancelled` 视为用户取消/超时的可重试错误而非初始化错误，以改善错误提示并保留诊断日志。  

### Description
- 在 `apps/web/src/app/[locale]/wallet/apple-pay/page.tsx` 的 `applePay.addEventListener?.("paymentMethodEnd", ...)` 中读取 `detail.status` 并添加分支处理：当 `status === "session_cancelled"` 时调用 `setError(...)`（中/英文提示为用户可重试），重置 `submittedTokenRef.current` 并返回；否则保留原有逻辑调用 `setInitError(buildApplePayElementErrorMessage(locale, detail))`。  
- 保留并不影响现有的 `postApplePayClientEvent` 上报和 `cloverRef.current?.updateApplePaymentStatus("failed")` 调用以便继续排查。  

### Testing
- 运行 `pnpm --filter web lint`，ESLint 报告无错误，测试通过。  
- 运行 `git diff --check` 没有发现问题。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ff45efe048327a56f4495484ef704)