### PR TITLE
增强 Apple Pay 事件日志记录

### DIFF
--- a/apps/web/src/app/[locale]/wallet/apple-pay/page.tsx
+++ b/apps/web/src/app/[locale]/wallet/apple-pay/page.tsx
@@ -76,12 +76,23 @@ function getApplePayToken(detail: Record<string, unknown> | undefined): string |
   return undefined;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
 function buildApplePayEventLog(detail: Record<string, unknown> | undefined) {
+  const tokenRecieved = isRecord(detail?.tokenRecieved) ? detail.tokenRecieved : undefined;
+  const tokenReceived = isRecord(detail?.tokenReceived) ? detail.tokenReceived : undefined;
+
   return {
     hasDetail: !!detail,
     detailKeys: detail ? Object.keys(detail) : [],
     hasTokenRecieved: !!detail?.tokenRecieved,
     hasTokenReceived: !!detail?.tokenReceived,
+    tokenRecievedKeys: tokenRecieved ? Object.keys(tokenRecieved) : [],
+    tokenReceivedKeys: tokenReceived ? Object.keys(tokenReceived) : [],
+    hasTokenRecievedId: typeof tokenRecieved?.id === "string" && tokenRecieved.id.length > 0,
+    hasTokenReceivedId: typeof tokenReceived?.id === "string" && tokenReceived.id.length > 0,
     status: typeof detail?.status === "string" ? detail.status : undefined,
     eventMessage: typeof detail?.eventMessage === "string" ? detail.eventMessage : undefined,
     message: typeof detail?.message === "string" ? detail.message : undefined,


### PR DESCRIPTION
### Motivation
- 防止将敏感支付数据（如 token 原文、卡号、DPAN、`paymentData` 等）写入日志，同时提供足够的非敏感元信息以便排查 Apple Pay 事件流和 token 是否存在或含 id。

### Description
- 在 `apps/web/src/app/[locale]/wallet/apple-pay/page.tsx` 中新增 `isRecord` 辅助函数并增强 `buildApplePayEventLog`，仅在 `detail?.tokenRecieved` 与 `detail?.tokenReceived` 为对象时读取其键名并添加 `tokenRecievedKeys`、`tokenReceivedKeys`、`hasTokenRecievedId`、`hasTokenReceivedId` 字段。 
- 只记录非敏感的键名和 id 存在性布尔值，明确避免记录 token 值或其它敏感 payment 字段。 
- 未改动事件绑定逻辑，现有的 `appleButtonClick`、`paymentMethodStart`、`paymentMethod`、`paymentAuthorize` 与 `paymentMethodEnd` 仍继续使用同一日志函数或统一的 token 处理流程。 

### Testing
- 运行了 `pnpm --filter web lint`，ESLint 校验通过且无报错。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ffa50062c8327be0daccaf0d2be1b)