### PR TITLE
Remove required contact fields from Apple Pay payment request

### DIFF
--- a/apps/web/src/app/[locale]/wallet/apple-pay/page.tsx
+++ b/apps/web/src/app/[locale]/wallet/apple-pay/page.tsx
@@ -535,8 +535,6 @@ export default function ApplePayWalletPage() {
           amount: ctx.totalCents,
           countryCode: "CA",
           currencyCode: ctx.currency || HOSTED_CHECKOUT_CURRENCY,
-          requiredBillingContactFields: ["postalAddress", "name"],
-          requiredShippingContactFields: ["email"],
         });
         console.debug("[AP][init] apple-request:created", {
           amount: appleReq.amount,


### PR DESCRIPTION
### Motivation
- The Apple Pay payment request previously set `requiredBillingContactFields` and `requiredShippingContactFields`, which can force collection of contact data and cause compatibility or UX issues on some devices.

### Description
- Stop including `requiredBillingContactFields` and `requiredShippingContactFields` in the `createApplePaymentRequest` call so the request no longer mandates those contact fields.
- No other changes to the Apple Pay flow or logging were made; the Clover instance and element creation remain unchanged.

### Testing
- Ran the project's unit test suite and TypeScript typecheck and both completed successfully.
- Ran lint checks and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5015c464c48327a86b86c5522445f5)