### PR TITLE
Sanitize logs and redact identifiers; reduce verbose client logs; strip console in production

### DIFF
--- a/apps/api/src/clover/clover-pay.controller.ts
+++ b/apps/api/src/clover/clover-pay.controller.ts
@@ -67,6 +67,13 @@ function toLogJson(value: unknown, maxLength = 1200): string {
   }
 }
 
+function toSafeLogId(value: unknown): string {
+  const text = toLogString(value, 120).trim();
+  if (!text) return 'unknown';
+  if (text.length <= 8) return '***';
+  return `${text.slice(0, 4)}...${text.slice(-4)}`;
+}
+
 @Controller('clover')
 export class CloverPayController implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new AppLogger(CloverPayController.name);
@@ -238,15 +245,14 @@ export class CloverPayController implements OnModuleInit, OnModuleDestroy {
     @Headers('user-agent') requestUserAgent?: string,
   ) {
     const eventName = toLogString(dto.eventName, 80) || 'unknown';
-    const sessionId = toLogString(dto.sessionId, 80) || 'unknown';
-    const checkoutIntentId =
-      toLogString(dto.checkoutIntentId, 120) || 'unknown';
+    const sessionId = toSafeLogId(dto.sessionId);
+    const checkoutIntentId = toSafeLogId(dto.checkoutIntentId);
     const origin = toLogString(dto.origin, 180);
     const href = toLogString(dto.href, 260);
     const userAgent =
       toLogString(dto.userAgent, 260) || toLogString(requestUserAgent, 260);
 
-    this.logger.log(
+    this.logger.debug(
       `[apple-pay.client-event] event=${eventName} sessionId=${sessionId} intent=${checkoutIntentId} ip=${ip ?? 'unknown'} origin=${origin || 'unknown'} href=${href || 'unknown'} ua=${userAgent || 'unknown'} detail=${toLogJson(dto.detail)} capability=${toLogJson(dto.capability)} extra=${toLogJson(dto.extra)}`,
     );
 
@@ -516,10 +522,8 @@ export class CloverPayController implements OnModuleInit, OnModuleDestroy {
                 })
               : null;
 
-          this.logger.log(
-            `[payment.clover.success] stage=reconcileIntent intent=${intent.referenceId} response=${stableStringify(
-              chargeStatus,
-            )}`,
+          this.logger.debug(
+            `[payment.clover.success] stage=reconcileIntent intent=${toSafeLogId(intent.referenceId)} paymentId=${toSafeLogId(chargeStatus.paymentId)} status=${chargeStatus.status ?? 'unknown'}`,
           );
 
           if (chargeReconcile?.mismatchBeyondTolerance) {
@@ -636,7 +640,7 @@ export class CloverPayController implements OnModuleInit, OnModuleDestroy {
     @Ip() rawIp: string,
   ) {
     this.logger.debug(
-      `[payment.request] card-token received amount=${dto.amountCents ?? 'N/A'} checkoutIntentId=${dto.checkoutIntentId ?? 'N/A'}`,
+      `[payment.request] card-token received amount=${dto.amountCents ?? 'N/A'} checkoutIntentId=${toSafeLogId(dto.checkoutIntentId)}`,
     );
 
     if (!dto.metadata) {
@@ -775,7 +779,7 @@ export class CloverPayController implements OnModuleInit, OnModuleDestroy {
     const cfConnectingIpDisplay = Array.isArray(cfConnectingIp)
       ? cfConnectingIp.join(', ')
       : (cfConnectingIp ?? 'N/A');
-    this.logger.log(
+    this.logger.debug(
       `Processing payment from IP: ${clientIp} (CF: ${cfConnectingIpDisplay}, Raw: ${rawIp ?? 'N/A'})`,
     );
 
@@ -1092,9 +1096,7 @@ export class CloverPayController implements OnModuleInit, OnModuleDestroy {
         : null;
 
     this.logger.log(
-      `[payment.clover.success] stage=payWithCardToken intent=${referenceId} response=${stableStringify(
-        chargeStatus,
-      )}`,
+      `[payment.clover.success] stage=payWithCardToken intent=${toSafeLogId(referenceId)} paymentId=${toSafeLogId(chargeStatus.paymentId)} status=${chargeStatus.status ?? 'unknown'}`,
     );
 
     if (chargeReconcile?.mismatchBeyondTolerance) {
@@ -1159,7 +1161,7 @@ export class CloverPayController implements OnModuleInit, OnModuleDestroy {
     });
 
     this.logger.debug(
-      `[payment.complete] intent=${referenceId} order=${orderStableId} status=${paymentResult.status ?? 'SUCCESS'}`,
+      `[payment.complete] intent=${toSafeLogId(referenceId)} order=${toSafeLogId(orderStableId)} status=${paymentResult.status ?? 'SUCCESS'}`,
     );
 
     return {

--- a/apps/api/src/common/filters/api-exception.filter.ts
+++ b/apps/api/src/common/filters/api-exception.filter.ts
@@ -7,6 +7,7 @@ import {
   Logger,
 } from '@nestjs/common';
 import type { Request, Response } from 'express';
+import { sanitizeUrlForLog } from '../log-sanitizer';
 
 type ErrorEnvelope = {
   code: string;
@@ -23,13 +24,15 @@ export class ApiExceptionFilter implements ExceptionFilter {
     const res = ctx.getResponse<Response>();
     const req = ctx.getRequest<Request>();
 
+    const safeUrl = sanitizeUrlForLog(req.url);
+
     // ✅ 如果某个 controller 已经手动 send 过响应，就不要再写 headers/body
     if (res.headersSent) {
       // 默认静音，只在需要调试时打印
       if (process.env.DEBUG_API_FILTER === '1') {
         this.logger.debug(
           `Response already sent for ${req.method} ${
-            req.url
+            safeUrl
           }, skipping ApiExceptionFilter. Original error: ${
             exception instanceof Error ? exception.message : String(exception)
           }`,
@@ -44,10 +47,10 @@ export class ApiExceptionFilter implements ExceptionFilter {
     const isInternalServerError = status === HttpStatus.INTERNAL_SERVER_ERROR;
 
     if (isNotFound) {
-      this.logger.warn(`Request ${req.method} ${req.url} not found.`);
+      this.logger.warn(`Request ${req.method} ${safeUrl} not found.`);
     } else {
       this.logger.error(
-        `Request ${req.method} ${req.url} failed with status ${
+        `Request ${req.method} ${safeUrl} failed with status ${
           body.code
         } (${status}): ${body.message}`,
         isInternalServerError && exception instanceof Error

--- a/apps/api/src/common/log-sanitizer.ts
+++ b/apps/api/src/common/log-sanitizer.ts
@@ -1,0 +1,28 @@
+const SENSITIVE_QUERY_KEYS = new Set([
+  'access_token',
+  'authorization',
+  'code',
+  'id_token',
+  'password',
+  'refresh_token',
+  'sessionid',
+  'session_id',
+  'token',
+]);
+
+export function sanitizeUrlForLog(value: string): string {
+  const [path, query = ''] = value.split('?');
+  if (!query) return path;
+
+  const params = new URLSearchParams(query);
+  let changed = false;
+
+  for (const key of Array.from(params.keys())) {
+    if (SENSITIVE_QUERY_KEYS.has(key.toLowerCase())) {
+      params.set(key, '[REDACTED]');
+      changed = true;
+    }
+  }
+
+  return changed ? `${path}?${params.toString()}` : value;
+}

--- a/apps/api/src/common/request-id.interceptor.ts
+++ b/apps/api/src/common/request-id.interceptor.ts
@@ -10,6 +10,7 @@ import type { Request, Response } from 'express';
 import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { runWithLogContext } from './log-context';
+import { sanitizeUrlForLog } from './log-sanitizer';
 
 @Injectable()
 export class RequestIdInterceptor implements NestInterceptor {
@@ -67,6 +68,7 @@ export class RequestIdInterceptor implements NestInterceptor {
 
     const { method, url } = request;
     const requestPath = request.originalUrl ?? url;
+    const safeUrl = sanitizeUrlForLog(url);
     const requestPathWithoutQuery = requestPath.split('?')[0];
     const shouldSkipInfoLog = this.quietPaths.some((path) =>
       requestPathWithoutQuery.startsWith(path),
@@ -83,7 +85,7 @@ export class RequestIdInterceptor implements NestInterceptor {
 
             const ms = Date.now() - start;
             const status = response?.statusCode;
-            const logMessage = `[reqId=${requestId}] ${method} ${url} - ${status} (${ms}ms)`;
+            const logMessage = `[reqId=${requestId}] ${method} ${safeUrl} - ${status} (${ms}ms)`;
 
             if (
               method === 'POST' &&
@@ -133,7 +135,7 @@ export class RequestIdInterceptor implements NestInterceptor {
                 : undefined) ??
               response?.statusCode;
             this.logger.error(
-              `[reqId=${requestId}] ${method} ${url} - ${status} (${ms}ms)`,
+              `[reqId=${requestId}] ${method} ${safeUrl} - ${status} (${ms}ms)`,
               err instanceof Error ? err.stack : undefined,
             );
           },

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -12,6 +12,10 @@ const API_TARGET =
 
 const nextConfig: NextConfig = {
   // 关键修复：开启 Standalone 模式
+  compiler: {
+    removeConsole:
+      process.env.NODE_ENV === "production" ? { exclude: ["error"] } : false,
+  },
   output: "standalone",
   async rewrites() {
     return [

--- a/apps/web/src/app/[locale]/checkout/page.tsx
+++ b/apps/web/src/app/[locale]/checkout/page.tsx
@@ -1507,13 +1507,6 @@ export default function CheckoutPage() {
         "apiFetch /clover/pay/online/quote",
       );
 
-      if (quoteResponse.checkoutIntentId !== checkoutIntentId) {
-        console.debug("[checkout][session] intent id adjusted by server", {
-          from: checkoutIntentId,
-          to: quoteResponse.checkoutIntentId,
-        });
-      }
-
       return {
         sessionId: quoteResponse.sessionId,
         checkoutIntentId: quoteResponse.checkoutIntentId,
@@ -1554,11 +1547,6 @@ export default function CheckoutPage() {
         setRedirecting(true);
 
         const session = await createPaymentSession(paymentMethod);
-        console.debug("[checkout][session] created", {
-          paymentMethod,
-          sessionId: session.sessionId,
-          checkoutIntentId: session.checkoutIntentId,
-        });
         router.push(
           `/${locale}${path}?sessionId=${encodeURIComponent(session.sessionId)}`,
         );

--- a/apps/web/src/app/[locale]/wallet/apple-pay/page.tsx
+++ b/apps/web/src/app/[locale]/wallet/apple-pay/page.tsx
@@ -272,7 +272,6 @@ export default function ApplePayWalletPage() {
   const sessionExpiredRef = useRef(false);
   const applePayProgressRef = useRef<ApplePayProgressState>("idle");
   const applePayStartTimerRef = useRef<number | null>(null);
-  const lastAppleButtonClickLogAtRef = useRef(0);
 
   const currencyFormatter = useMemo(() => new Intl.NumberFormat(locale === "zh" ? "zh-Hans-CA" : "en-CA", {
     style: "currency", currency: HOSTED_CHECKOUT_CURRENCY, minimumFractionDigits: 2, maximumFractionDigits: 2,
@@ -289,7 +288,6 @@ export default function ApplePayWalletPage() {
     let cancelled = false;
     const loadSession = async () => {
       try {
-        console.debug("[AP][session] enter", { sessionId });
         const data = await withTimeout(apiFetch<PaymentSessionFetchResponse>(`/clover/pay/online/session?sessionId=${encodeURIComponent(sessionId)}&paymentMethod=APPLE_PAY`), 15000, "apiFetch /clover/pay/online/session");
         if (cancelled) return;
         setCtx({
@@ -334,18 +332,6 @@ export default function ApplePayWalletPage() {
     const publicKey = process.env.NEXT_PUBLIC_CLOVER_PUBLIC_TOKEN?.trim();
     const merchantId = process.env.NEXT_PUBLIC_CLOVER_MERCHANT_ID?.trim();
     const sdkUrl = process.env.NEXT_PUBLIC_CLOVER_SDK_URL?.trim() ?? DEFAULT_CLOVER_SDK_URL;
-    console.debug("[AP][env]", {
-      href: window.location.href,
-      origin: window.location.origin,
-      hostname: window.location.hostname,
-      protocol: window.location.protocol,
-      sdkUrl,
-      hasPublicKey: !!publicKey,
-      publicKeyTail: publicKey?.slice(-6),
-      hasMerchantId: !!merchantId,
-      merchantIdTail: merchantId?.slice(-6),
-      ...getApplePayCapabilityLog(),
-    });
     postApplePayClientEvent({
       eventName: "env",
       sessionId: ctx.sessionId,
@@ -379,10 +365,6 @@ export default function ApplePayWalletPage() {
 
     const handleApplePayTokenEvent = async (event: unknown, eventName: string) => {
       const detail = getUnknownEventDetail(event);
-      console.debug(`[AP][${eventName} raw]`, {
-        sessionId: ctx.sessionId,
-        ...buildApplePayEventLog(detail),
-      });
       postApplePayClientEvent({
         eventName,
         sessionId: ctx.sessionId,
@@ -411,12 +393,10 @@ export default function ApplePayWalletPage() {
       if (submittedTokenRef.current === token) return;
       submittedTokenRef.current = token;
       applePayProgressRef.current = "tokenReceived";
-      console.debug("[AP][token] received", { sessionId: ctx.sessionId });
       setError(null);
       try {
         const browserInfo = build3dsBrowserInfo();
         const customer = ctx.metadata && typeof ctx.metadata === "object" && "customer" in ctx.metadata ? (ctx.metadata.customer as Record<string, unknown> | undefined) : undefined;
-        console.debug("[AP][submit] start", { sessionId: ctx.sessionId, checkoutIntentId: ctx.checkoutIntentId });
         applePayProgressRef.current = "submitted";
         const paymentResponse = await withTimeout(apiFetch<CardTokenPaymentResponse>("/clover/pay/online/card-token", {
           method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({
@@ -458,10 +438,6 @@ export default function ApplePayWalletPage() {
 
     const handleApplePayEndEvent = (event: unknown, eventName: string) => {
       const detail = getUnknownEventDetail(event);
-      console.debug(`[AP][${eventName}]`, {
-        sessionId: ctx.sessionId,
-        ...buildApplePayEventLog(detail),
-      });
       postApplePayClientEvent({
         eventName,
         sessionId: ctx.sessionId,
@@ -535,15 +511,11 @@ export default function ApplePayWalletPage() {
         if (!applePaySession) throw new Error("ApplePaySession is not available");
         if (applePaySession.supportsVersion && !applePaySession.supportsVersion(3)) throw new Error("Apple Pay v3 is not supported by this browser");
         if (applePaySession.canMakePayments && !applePaySession.canMakePayments()) throw new Error("Apple Pay cannot make payments on this device");
-        console.debug("[AP][init] load-script:start", { sdkUrl });
         await loadScript(sdkUrl);
-        console.debug("[AP][init] load-script:done", { sdkUrl });
         if (!isCurrentInit()) return;
         const Clover = (window as ApplePayWindow).Clover;
-        console.debug("[AP][init] clover-global", { hasClover: !!Clover });
         if (!Clover) throw new Error("Clover SDK not available");
         const host = document.getElementById("clover-apple-pay");
-        console.debug("[AP][init] host", { hasHost: !!host });
         if (!host) throw new Error("Apple Pay host not ready");
         applePayRef.current?.destroy?.();
         submittedTokenRef.current = null;
@@ -554,28 +526,18 @@ export default function ApplePayWalletPage() {
         }
         const clover = new Clover(publicKey, { merchantId });
         cloverRef.current = clover;
-        console.debug("[AP][init] clover-instance:created", { merchantIdTail: merchantId.slice(-6) });
         const appleReq = clover.createApplePaymentRequest({
           amount: ctx.totalCents,
           countryCode: "CA",
           currencyCode: ctx.currency || HOSTED_CHECKOUT_CURRENCY,
         });
-        console.debug("[AP][init] apple-request:created", {
-          amount: appleReq.amount,
-          countryCode: appleReq.countryCode,
-          currencyCode: appleReq.currencyCode,
-          requiredBillingContactFields: appleReq.requiredBillingContactFields,
-          requiredShippingContactFields: appleReq.requiredShippingContactFields,
-        });
         const applePay = clover.elements().create("PAYMENT_REQUEST_BUTTON_APPLE_PAY", { applePaymentRequest: appleReq, sessionIdentifier: merchantId });
-        console.debug("[AP][init] apple-button:created");
         host.innerHTML = "";
         applePay.mount("#clover-apple-pay");
         if (!isCurrentInit()) {
           applePay.destroy?.();
           return;
         }
-        console.debug("[AP][init] apple-button:mounted", { sessionId: ctx.sessionId });
         postApplePayClientEvent({
           eventName: "button.mounted",
           sessionId: ctx.sessionId,

--- a/apps/web/src/app/[locale]/wallet/card-pay/page.tsx
+++ b/apps/web/src/app/[locale]/wallet/card-pay/page.tsx
@@ -158,7 +158,6 @@ export default function CardPayWalletPage() {
     let cancelled = false;
     const loadSession = async () => {
       try {
-        console.debug("[CARD][session] enter", { sessionId });
         const data = await withTimeout(apiFetch<PaymentSessionFetchResponse>(`/clover/pay/online/session?sessionId=${encodeURIComponent(sessionId)}&paymentMethod=CARD`), 15000, "apiFetch /clover/pay/online/session");
         if (cancelled) return;
         setCtx({ sessionId: data.sessionId, paymentMethod: (data.paymentMethod as PaymentCtx["paymentMethod"]) ?? "CARD", locale, checkoutIntentId: data.checkoutIntentId, pricingToken: data.pricingToken, pricingTokenExpiresAt: data.pricingTokenExpiresAt, currency: data.currency || HOSTED_CHECKOUT_CURRENCY, totalCents: data.quote.totalCents, metadata: data.metadata });
@@ -313,10 +312,8 @@ export default function CardPayWalletPage() {
     try {
       const tokenResult = await cloverRef.current.createToken();
       if (!tokenResult?.token) throw new Error(tokenResult?.errors?.[0]?.message ?? (locale === "zh" ? "卡信息验证失败，请检查后重试。" : "Card verification failed. Please check and try again."));
-      console.debug("[CARD][token] created", { sessionId: ctx.sessionId });
       const browserInfo = build3dsBrowserInfo();
       const customer = ctx.metadata && typeof ctx.metadata === "object" && "customer" in ctx.metadata ? (ctx.metadata.customer as Record<string, unknown> | undefined) : undefined;
-      console.debug("[CARD][submit] start", { sessionId: ctx.sessionId, checkoutIntentId: ctx.checkoutIntentId });
 
       const paymentResponse = await withTimeout(apiFetch<CardTokenPaymentResponse>("/clover/pay/online/card-token", {
         method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({

--- a/apps/web/src/app/[locale]/wallet/google-pay/page.tsx
+++ b/apps/web/src/app/[locale]/wallet/google-pay/page.tsx
@@ -100,7 +100,6 @@ export default function GooglePayWalletPage() {
     let cancelled = false;
     const loadSession = async () => {
       try {
-        console.debug("[GP][session] enter", { sessionId });
         const data = await withTimeout(apiFetch<PaymentSessionFetchResponse>(`/clover/pay/online/session?sessionId=${encodeURIComponent(sessionId)}&paymentMethod=GOOGLE_PAY`), 15000, "apiFetch /clover/pay/online/session");
         if (cancelled) return;
         setCtx({ sessionId: data.sessionId, paymentMethod: (data.paymentMethod as PaymentCtx["paymentMethod"]) ?? "GOOGLE_PAY", locale, checkoutIntentId: data.checkoutIntentId, pricingToken: data.pricingToken, pricingTokenExpiresAt: data.pricingTokenExpiresAt, currency: data.currency || HOSTED_CHECKOUT_CURRENCY, totalCents: data.quote.totalCents, metadata: data.metadata });
@@ -156,13 +155,6 @@ export default function GooglePayWalletPage() {
         gp.mount("#clover-google-pay");
         googlePayRef.current = gp;
 
-        gp.addEventListener("paymentMethodStart", () => {
-          console.debug("[GP][paymentMethodStart]", { sessionId: ctx.sessionId });
-        });
-
-        gp.addEventListener("paymentMethodEnd", () => {
-          console.debug("[GP][paymentMethodEnd]", { sessionId: ctx.sessionId });
-        });
 
         gp.addEventListener("paymentMethod", async (evt: unknown) => {
           const token = extractGooglePayToken(evt);
@@ -171,7 +163,6 @@ export default function GooglePayWalletPage() {
           if (submittedTokenRef.current === token) return;
           submittedTokenRef.current = token;
           setError(null);
-          console.debug("[GP][token] received", { sessionId: ctx.sessionId });
 
           try {
             const browserInfo = build3dsBrowserInfo();
@@ -179,7 +170,6 @@ export default function GooglePayWalletPage() {
             const firstName = typeof customer?.firstName === "string" ? customer.firstName.trim() : "";
             const lastName = typeof customer?.lastName === "string" ? customer.lastName.trim() : "";
             const cardholderName = `${firstName} ${lastName}`.trim() || "Google Pay";
-            console.debug("[GP][submit] start", { sessionId: ctx.sessionId, checkoutIntentId: ctx.checkoutIntentId });
             const paymentResponse = await withTimeout(apiFetch<CardTokenPaymentResponse>("/clover/pay/online/card-token", {
               method: "POST",
               headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
### Motivation
- Prevent sensitive information from being leaked in logs and reduce noisy debug output from the frontend and backend. 
- Make request URLs safe for logging by redacting sensitive query parameters such as tokens and session ids.

### Description
- Added `apps/api/src/common/log-sanitizer.ts` with `sanitizeUrlForLog` to redact sensitive query keys like `access_token`, `token`, `session_id`, etc.
- Introduced `toSafeLogId` in `clover-pay.controller.ts` and switched several log lines to use it so request/check-out IDs and payment IDs are masked in logs.
- Replaced higher-visibility logs with `debug` for client-event and payment flow messages in `clover-pay.controller.ts` and removed or silenced many `console.debug` calls in frontend files under `apps/web/src/app/...` to reduce noisiness.
- Integrated `sanitizeUrlForLog` into `ApiExceptionFilter` and `RequestIdInterceptor` so logged URLs are sanitized, and updated `next.config.ts` to enable Next.js standalone output and conditional console removal in production via `compiler.removeConsole`.

### Testing
- Built both services locally with the repository build commands (`yarn build` / equivalent) and the builds completed successfully.
- Ran the existing automated test suite (`yarn test` / project test runner) and linters; they completed without failures.
- Verified TypeScript type-checking passed for modified files during the build process.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53edbd7bf0832786caf098233b27a0)