### PR TITLE
减少 Clover charge status 日志噪音并优化查询顺序

### DIFF
--- a/apps/api/src/clover/clover.service.ts
+++ b/apps/api/src/clover/clover.service.ts
@@ -280,6 +280,23 @@ export class CloverService {
     }
 
     if (externalPaymentId) {
+      if (paymentId) {
+        const byPaymentId = await this.queryChargeStatusByFilters([
+          {
+            query: `id=${encodeURIComponent(paymentId)}`,
+            matcher: (charge) => charge.paymentId === paymentId,
+          },
+          {
+            query: `paymentId=${encodeURIComponent(paymentId)}`,
+            matcher: (charge) => charge.paymentId === paymentId,
+          },
+        ]);
+
+        if (byPaymentId.ok) {
+          return byPaymentId.result;
+        }
+      }
+
       const byExternalPaymentId = await this.queryChargeStatusByFilters([
         {
           query: `externalPaymentId=${encodeURIComponent(externalPaymentId)}`,
@@ -296,23 +313,6 @@ export class CloverService {
       ]);
       if (byExternalPaymentId.ok) {
         return byExternalPaymentId.result;
-      }
-
-      if (paymentId) {
-        const byPaymentIdFallback = await this.queryChargeStatusByFilters([
-          {
-            query: `id=${encodeURIComponent(paymentId)}`,
-            matcher: (charge) => charge.paymentId === paymentId,
-          },
-          {
-            query: `paymentId=${encodeURIComponent(paymentId)}`,
-            matcher: (charge) => charge.paymentId === paymentId,
-          },
-        ]);
-
-        if (byPaymentIdFallback.ok) {
-          return byPaymentIdFallback.result;
-        }
       }
 
       return {
@@ -421,7 +421,7 @@ export class CloverService {
     }
 
     this.logger.debug(
-      `[CloverService] charge status raw response url=${url} payload=${safeSerializeForLog(parsed ?? rawText)}`,
+      `[CloverService] charge status response url=${url} ok=${resp.ok} status=${resp.status} chargeCount=${extractChargeRecords(parsed).length}`,
     );
 
     if (!resp.ok) {


### PR DESCRIPTION
### Motivation
- 避免把 Clover 返回的完整 charges 列表（含卡号片段、auth/ref 等敏感信息）大量打印到 API 日志中以降低噪音与泄露风险。 
- 当同时有 `paymentId` 与 `externalPaymentId` 时，当前查询顺序会触发多次 list 查询导致重复记录与额外开销，需优先使用更精确的 `paymentId` 查询以减少查询次数。

### Description
- 在 `apps/api/src/clover/clover.service.ts` 中，当同时提供 `paymentId` 与 `externalPaymentId` 时优先执行 `paymentId` 的查询路由，若找不到再回退到 `externalPaymentId` 查询，从而减少正常路径的 list 查询次数。 
- 将 verbose 的 debug 日志 `charge status raw response` 替换为简短的摘要日志，改为输出 `ok/status/chargeCount`，避免在日志中 dump 最近 charge 的完整 JSON。 
- 修改已提交（commit 信息：`Reduce Clover charge status log noise`）。

### Testing
- 运行 `pnpm --filter api test -- clover.service.spec.ts --runInBand`，Clover 相关单元测试全部通过。 
- 运行 `pnpm --filter api test -- --runInBand`（全套 API 测试）时失败，失败原因为现有模块解析问题：`Cannot find module '@shared/menu'`，出现在与本次改动无关的 `orders.service.spec.ts`，因此无法完整跑通整套测试。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53f7a64d9483278db364b81d1d7065)