### PR TITLE
fix(api): remove unused Clover log serializer

### DIFF
--- a/apps/api/src/clover/clover.service.ts
+++ b/apps/api/src/clover/clover.service.ts
@@ -727,18 +727,3 @@ function stringifyReason(
 
   return fallbackMessage?.trim() || 'Clover request failed';
 }
-
-function safeSerializeForLog(value: unknown): string {
-  if (typeof value === 'string') {
-    return value;
-  }
-
-  try {
-    const serialized = JSON.stringify(value);
-    return serialized && serialized.length > 0
-      ? serialized
-      : '[unserializable-empty]';
-  } catch {
-    return '[unserializable]';
-  }
-}


### PR DESCRIPTION
### Motivation
- 修复 ESLint 报错 `@typescript-eslint/no-unused-vars`，因为 `apps/api/src/clover/clover.service.ts` 中存在未使用的 `safeSerializeForLog` 辅助函数。

### Description
- 从 `apps/api/src/clover/clover.service.ts` 中移除未使用的 `safeSerializeForLog` 函数以清理代码并消除 lint 错误，保留 `stringifyReason` 等实际使用的逻辑。

### Testing
- 运行 `pnpm --filter api lint`，包含子包构建和 `prisma generate`，Lint 检查通过且未再报未使用变量错误。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53fc50fe4c8327be92d56d88709e39)