### PR TITLE
fix(api): handle missing Clover charge payload

### DIFF
--- a/apps/api/src/clover/clover.service.ts
+++ b/apps/api/src/clover/clover.service.ts
@@ -570,8 +570,10 @@ function pickString(
 }
 
 function extractChargeRecords(
-  payload: Record<string, unknown>,
+  payload: Record<string, unknown> | undefined,
 ): Record<string, unknown>[] {
+  if (!payload) return [];
+
   const data = payload.data;
   if (Array.isArray(data)) {
     return data.filter(


### PR DESCRIPTION
### Motivation
- 修复在处理 Clover 响应解析时的 TypeScript 严格空值错误（`TS2345`），避免把可能为 `undefined` 的 `parsed` 传入只接受 `Record<string, unknown>` 的函数。 

### Description
- 将 `extractChargeRecords` 签名改为接受 `Record<string, unknown> | undefined` 并在 `payload` 缺失时返回空数组，变更文件为 `apps/api/src/clover/clover.service.ts`，以保证调用处（例如日志输出）不会触发类型错误。 

### Testing
- 运行 `pnpm --filter api build`（构建过程包含 `prisma generate` 及 TypeScript 编译）并已成功通过。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54012b0d048327bf37533953f56e0c)