### PR TITLE
Order-ready: add email templates and support email+SMS notifications

### DIFF
--- a/apps/api/src/messaging/template-vars.ts
+++ b/apps/api/src/messaging/template-vars.ts
@@ -35,8 +35,8 @@ export type GiftIssuedVars = BaseVars & {
 };
 
 export type OrderReadyVars = BaseVars & {
+  userName?: string;
   pickupCode: string;
-  pickupLocation?: string;
 };
 
 export type InvoiceVars = BaseVars & {

--- a/apps/api/src/messaging/templates/en/orderReady.email.html.hbs
+++ b/apps/api/src/messaging/templates/en/orderReady.email.html.hbs
@@ -1,0 +1,12 @@
+<h1>Your order is ready</h1>
+
+<p>Hello {{userName}},</p>
+
+<p>Your order is ready for pickup.</p>
+
+<ul>
+  <li>Pickup code: {{pickupCode}}</li>
+  {{#if storeAddressLine}}<li>Store address: {{storeAddressLine}}</li>{{/if}}
+</ul>
+
+<p>Thank you for choosing {{brandName}}.</p>

--- a/apps/api/src/messaging/templates/en/orderReady.email.subject.hbs
+++ b/apps/api/src/messaging/templates/en/orderReady.email.subject.hbs
@@ -1,0 +1,1 @@
+{{brandName}} Order Ready: {{pickupCode}}

--- a/apps/api/src/messaging/templates/en/orderReady.email.text.hbs
+++ b/apps/api/src/messaging/templates/en/orderReady.email.text.hbs
@@ -1,0 +1,7 @@
+Hello {{userName}},
+
+Your order is ready for pickup.
+Pickup code: {{pickupCode}}
+{{storeAddressLine}}
+
+Thank you for choosing {{brandName}}.

--- a/apps/api/src/messaging/templates/en/orderReady.sms.hbs
+++ b/apps/api/src/messaging/templates/en/orderReady.sms.hbs
@@ -1,1 +1,1 @@
-{{smsSignature}}Your order is ready. Pickup code: {{pickupCode}}. {{pickupLocation}}. {{storeAddressLine}}
+{{smsSignature}}Your order is ready. Pickup code: {{pickupCode}}. {{storeAddressLine}}

--- a/apps/api/src/messaging/templates/zh-CN/orderReady.email.html.hbs
+++ b/apps/api/src/messaging/templates/zh-CN/orderReady.email.html.hbs
@@ -1,0 +1,12 @@
+<h1>您的订单已备好</h1>
+
+<p>您好{{userName}}，</p>
+
+<p>您的订单已备好，可以取餐了。</p>
+
+<ul>
+  <li>取餐码：{{pickupCode}}</li>
+  {{#if storeAddressLine}}<li>门店地址：{{storeAddressLine}}</li>{{/if}}
+</ul>
+
+<p>感谢您选择 {{brandName}}。</p>

--- a/apps/api/src/messaging/templates/zh-CN/orderReady.email.subject.hbs
+++ b/apps/api/src/messaging/templates/zh-CN/orderReady.email.subject.hbs
@@ -1,0 +1,1 @@
+{{brandName}} 订单已备好：{{pickupCode}}

--- a/apps/api/src/messaging/templates/zh-CN/orderReady.email.text.hbs
+++ b/apps/api/src/messaging/templates/zh-CN/orderReady.email.text.hbs
@@ -1,0 +1,7 @@
+您好{{userName}}，
+
+您的订单已备好，可以取餐了。
+取餐码：{{pickupCode}}
+{{storeAddressLine}}
+
+感谢您选择 {{brandName}}。

--- a/apps/api/src/messaging/templates/zh-CN/orderReady.sms.hbs
+++ b/apps/api/src/messaging/templates/zh-CN/orderReady.sms.hbs
@@ -1,1 +1,1 @@
-{{smsSignature}}您的订单已备好，取餐码：{{pickupCode}}。{{pickupLocation}}。{{storeAddressLine}}
+{{smsSignature}}您的订单已备好，取餐码：{{pickupCode}}。{{storeAddressLine}}

--- a/apps/api/src/notifications/notification.service.ts
+++ b/apps/api/src/notifications/notification.service.ts
@@ -164,28 +164,58 @@ export class NotificationService {
   }
 
   async notifyOrderReady(params: {
-    phone: string;
+    email?: string | null;
+    phone?: string | null;
     orderNumber: string;
     name?: string | null;
     locale?: string;
+    userId?: string | null;
   }) {
     const locale = params.locale?.toLowerCase().startsWith('zh') ? 'zh' : 'en';
     const { baseVars } =
       await this.businessConfigService.getMessagingSnapshot(locale);
-    const body = await this.templateRenderer.renderSms({
-      template: 'orderReady',
-      locale,
-      vars: {
-        ...baseVars,
-        pickupCode: params.orderNumber,
-      },
-    });
-    return this.smsService.sendSms({
-      phone: params.phone,
-      body,
-      templateType: MessagingTemplateType.ORDER_READY,
-      locale,
-    });
+    const vars = {
+      ...baseVars,
+      userName:
+        params.name?.trim() || (locale === 'zh' ? '亲爱的顾客' : 'Dear Customer'),
+      pickupCode: params.orderNumber,
+    };
+
+    if (params.email) {
+      const { subject, html, text } = await this.templateRenderer.renderEmail({
+        template: 'orderReady',
+        locale,
+        vars,
+      });
+
+      return this.emailService.sendEmail({
+        to: params.email,
+        subject,
+        html,
+        text,
+        tags: { type: 'order_ready' },
+        locale: locale === 'zh' ? 'zh-CN' : 'en',
+        templateType: MessagingTemplateType.ORDER_READY,
+        userId: params.userId ?? undefined,
+        metadata: { trigger: 'order_ready' },
+      });
+    }
+
+    if (params.phone) {
+      const body = await this.templateRenderer.renderSms({
+        template: 'orderReady',
+        locale,
+        vars,
+      });
+      return this.smsService.sendSms({
+        phone: params.phone,
+        body,
+        templateType: MessagingTemplateType.ORDER_READY,
+        locale,
+        userId: params.userId ?? undefined,
+        metadata: { trigger: 'order_ready' },
+      });
+    }
   }
 
   async notifyDeliveryDispatchFailed(params: {

--- a/apps/api/src/orders/orders.service.spec.ts
+++ b/apps/api/src/orders/orders.service.spec.ts
@@ -224,7 +224,7 @@ describe('OrdersService', () => {
     );
   });
 
-  it('sends order-ready SMS when pickup order is marked ready', async () => {
+  it('sends order-ready notification with phone when pickup order is marked ready and no email exists', async () => {
     prisma.order.findUnique
       .mockResolvedValueOnce({
         status: 'making',
@@ -248,12 +248,87 @@ describe('OrdersService', () => {
       '11111111-1111-1111-1111-111111111111',
       'ready',
     );
-    await Promise.resolve();
+    await new Promise(process.nextTick);
 
     expect(notificationService.notifyOrderReady).toHaveBeenCalledTimes(1);
+    expect(notificationService.notifyOrderReady).toHaveBeenCalledWith({
+      email: null,
+      phone: '+14165550000',
+      orderNumber: 'cordpickupready001',
+      name: 'Test',
+      locale: 'en',
+      userId: null,
+    });
   });
 
-  it('does not send order-ready SMS when delivery order is marked ready', async () => {
+  it('sends order-ready notification with email when pickup order has a member email', async () => {
+    prisma.order.findUnique
+      .mockResolvedValueOnce({
+        status: 'making',
+        paidAt: new Date('2024-01-01T00:00:00.000Z'),
+        makingAt: new Date('2024-01-01T00:05:00.000Z'),
+        fulfillmentType: 'pickup',
+      })
+      .mockResolvedValueOnce({
+        id: 'order-pickup-ready-email',
+        orderStableId: 'cordpickupready002',
+        clientRequestId: null,
+        contactPhone: '+14165550000',
+        contactName: 'Email Test',
+        userId: 'user-1',
+        fulfillmentType: 'pickup',
+        items: [],
+      });
+    prisma.checkoutIntent.findFirst.mockResolvedValue({ locale: 'en' });
+    prisma.user.findUnique.mockResolvedValue({ email: 'member@example.com' });
+
+    await service.updateStatusInternal(
+      '33333333-3333-3333-3333-333333333333',
+      'ready',
+    );
+    await new Promise(process.nextTick);
+
+    expect(notificationService.notifyOrderReady).toHaveBeenCalledTimes(1);
+    expect(notificationService.notifyOrderReady).toHaveBeenCalledWith({
+      email: 'member@example.com',
+      phone: '+14165550000',
+      orderNumber: 'cordpickupready002',
+      name: 'Email Test',
+      locale: 'en',
+      userId: 'user-1',
+    });
+  });
+
+  it('does not send order-ready notification when pickup order has no email or phone', async () => {
+    prisma.order.findUnique
+      .mockResolvedValueOnce({
+        status: 'making',
+        paidAt: new Date('2024-01-01T00:00:00.000Z'),
+        makingAt: new Date('2024-01-01T00:05:00.000Z'),
+        fulfillmentType: 'pickup',
+      })
+      .mockResolvedValueOnce({
+        id: 'order-pickup-ready-no-contact',
+        orderStableId: 'cordpickupready003',
+        clientRequestId: null,
+        contactPhone: null,
+        contactName: 'No Contact',
+        userId: null,
+        fulfillmentType: 'pickup',
+        items: [],
+      });
+    prisma.checkoutIntent.findFirst.mockResolvedValue({ locale: 'en' });
+
+    await service.updateStatusInternal(
+      '44444444-4444-4444-4444-444444444444',
+      'ready',
+    );
+    await new Promise(process.nextTick);
+
+    expect(notificationService.notifyOrderReady).not.toHaveBeenCalled();
+  });
+
+  it('does not send order-ready notification when delivery order is marked ready', async () => {
     prisma.order.findUnique
       .mockResolvedValueOnce({
         status: 'making',
@@ -276,7 +351,7 @@ describe('OrdersService', () => {
       '22222222-2222-2222-2222-222222222222',
       'ready',
     );
-    await Promise.resolve();
+    await new Promise(process.nextTick);
 
     expect(notificationService.notifyOrderReady).not.toHaveBeenCalled();
   });

--- a/apps/api/src/orders/orders.service.ts
+++ b/apps/api/src/orders/orders.service.ts
@@ -849,17 +849,28 @@ export class OrdersService {
       return;
     }
 
-    if (!order.contactPhone) return;
     const orderNumber = order.clientRequestId ?? order.orderStableId;
     if (!orderNumber) return;
 
     const locale = await this.resolveOrderReadyLocale(order);
+    const member = order.userId
+      ? await this.prisma.user.findUnique({
+          where: { id: order.userId },
+          select: { email: true },
+        })
+      : null;
+    const email = member?.email ?? null;
+    const phone = order.contactPhone ?? null;
+
+    if (!email && !phone) return;
 
     await this.notificationService.notifyOrderReady({
-      phone: order.contactPhone,
+      email,
+      phone,
       orderNumber,
       name: order.contactName ?? null,
       locale,
+      userId: order.userId ?? null,
     });
   }
 


### PR DESCRIPTION
### Motivation

- Enable sending order-ready notifications via email when a member has an email address while keeping SMS as a fallback.  
- Include recipient display name and store address in order-ready messages and remove deprecated `pickupLocation`.  
- Provide localized templates for English and Chinese (`zh-CN`) for email and SMS.

### Description

- Added `userName?: string` to `OrderReadyVars` and removed `pickupLocation` from template vars.  
- Added order-ready templates for `en` and `zh-CN` (HTML, text, subject) and updated SMS templates to use `storeAddressLine`.  
- Updated `NotificationService.notifyOrderReady` to accept `email?` and `phone?`, render and send email when `email` is present, and fallback to SMS; included `userId`, `locale` mapping, and metadata/tags.  
- Updated `OrdersService` to fetch a member's email when present, derive locale, avoid sending if neither email nor phone exist, and pass `email`, `phone`, and `userId` into the notification call.  
- Updated `orders.service.spec.ts` to cover phone-only, email-present, and no-contact scenarios and adjusted async waits to use `process.nextTick`.

### Testing

- Ran unit tests for `OrdersService` (updated `orders.service.spec.ts`) which exercise phone-only, email, and no-contact flows; all affected tests passed.  
- Overall test suite run with `yarn test` completed successfully for the modified modules.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a540a003b24832795327a752ba340d8)