### PR TITLE
fix(api): resolve lint errors

### DIFF
--- a/apps/api/src/notifications/notification.service.ts
+++ b/apps/api/src/notifications/notification.service.ts
@@ -177,7 +177,8 @@ export class NotificationService {
     const vars = {
       ...baseVars,
       userName:
-        params.name?.trim() || (locale === 'zh' ? '亲爱的顾客' : 'Dear Customer'),
+        params.name?.trim() ||
+        (locale === 'zh' ? '亲爱的顾客' : 'Dear Customer'),
       pickupCode: params.orderNumber,
     };
 

--- a/apps/api/src/orders/orders.service.spec.ts
+++ b/apps/api/src/orders/orders.service.spec.ts
@@ -248,7 +248,7 @@ describe('OrdersService', () => {
       '11111111-1111-1111-1111-111111111111',
       'ready',
     );
-    await new Promise(process.nextTick);
+    await new Promise<void>((resolve) => process.nextTick(resolve));
 
     expect(notificationService.notifyOrderReady).toHaveBeenCalledTimes(1);
     expect(notificationService.notifyOrderReady).toHaveBeenCalledWith({
@@ -286,7 +286,7 @@ describe('OrdersService', () => {
       '33333333-3333-3333-3333-333333333333',
       'ready',
     );
-    await new Promise(process.nextTick);
+    await new Promise<void>((resolve) => process.nextTick(resolve));
 
     expect(notificationService.notifyOrderReady).toHaveBeenCalledTimes(1);
     expect(notificationService.notifyOrderReady).toHaveBeenCalledWith({
@@ -323,7 +323,7 @@ describe('OrdersService', () => {
       '44444444-4444-4444-4444-444444444444',
       'ready',
     );
-    await new Promise(process.nextTick);
+    await new Promise<void>((resolve) => process.nextTick(resolve));
 
     expect(notificationService.notifyOrderReady).not.toHaveBeenCalled();
   });
@@ -351,7 +351,7 @@ describe('OrdersService', () => {
       '22222222-2222-2222-2222-222222222222',
       'ready',
     );
-    await new Promise(process.nextTick);
+    await new Promise<void>((resolve) => process.nextTick(resolve));
 
     expect(notificationService.notifyOrderReady).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
### Motivation
- 修复 CI/本地 lint 报错，解决 Prettier 换行格式问题和 `@typescript-eslint/unbound-method` 警告。

### Description
- 调整 `apps/api/src/notifications/notification.service.ts` 中 `userName` 的换行以符合 Prettier 要求。
- 在 `apps/api/src/orders/orders.service.spec.ts` 中将多处 `await new Promise(process.nextTick);` 替换为 `await new Promise<void>((resolve) => process.nextTick(resolve));` 以消除未绑定 `this` 的 lint 警告。

### Testing
- 运行 `pnpm --filter api lint` 并通过，lint 检查成功。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a540f2122d88327bc576c7bf468f77f)