### PR TITLE
feat(checkout): prefer email OTP and add checkout email verification

### DIFF
--- a/apps/api/src/email/email-checkout-verification.controller.ts
+++ b/apps/api/src/email/email-checkout-verification.controller.ts
@@ -1,0 +1,70 @@
+import { BadRequestException, Body, Controller, Post } from '@nestjs/common';
+import {
+  IsEmail,
+  IsIn,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+} from 'class-validator';
+import { EmailVerificationService } from './email-verification.service';
+
+class SendCheckoutEmailCodeDto {
+  @IsEmail()
+  email!: string;
+
+  @IsOptional()
+  @IsString()
+  locale?: string;
+
+  @IsOptional()
+  @IsIn(['checkout'])
+  purpose?: 'checkout';
+}
+
+class VerifyCheckoutEmailCodeDto {
+  @IsEmail()
+  email!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  code!: string;
+
+  @IsOptional()
+  @IsIn(['checkout'])
+  purpose?: 'checkout';
+}
+
+@Controller('email/checkout')
+export class EmailCheckoutVerificationController {
+  constructor(private readonly service: EmailVerificationService) {}
+
+  @Post('send-code')
+  async sendCode(@Body() body: SendCheckoutEmailCodeDto) {
+    const result = await this.service.requestCheckoutVerification({
+      email: body.email,
+      locale: body.locale,
+      purpose: body.purpose ?? 'checkout',
+    });
+
+    if (!result.ok) {
+      throw new BadRequestException(result.error ?? 'email_send_failed');
+    }
+
+    return result;
+  }
+
+  @Post('verify-code')
+  async verifyCode(@Body() body: VerifyCheckoutEmailCodeDto) {
+    const result = await this.service.verifyCheckoutToken({
+      email: body.email,
+      token: body.code,
+      purpose: body.purpose ?? 'checkout',
+    });
+
+    if (!result.ok) {
+      throw new BadRequestException(result.error ?? 'token_invalid');
+    }
+
+    return result;
+  }
+}

--- a/apps/api/src/email/email-verification.service.ts
+++ b/apps/api/src/email/email-verification.service.ts
@@ -73,6 +73,108 @@ export class EmailVerificationService {
     return { ok: true };
   }
 
+  async requestCheckoutVerification(params: {
+    email: string;
+    locale?: string;
+    purpose?: 'checkout';
+  }) {
+    const normalized = normalizeEmail(params.email);
+    if (!normalized) {
+      return { ok: false, error: 'invalid_email' };
+    }
+
+    const now = new Date();
+    const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+    const dailyCount = await this.prisma.authChallenge.count({
+      where: {
+        type: AuthChallengeType.EMAIL_VERIFY,
+        channel: MessagingChannel.EMAIL,
+        addressNorm: normalized,
+        purpose: params.purpose ?? 'checkout',
+        createdAt: { gt: oneDayAgo },
+      },
+    });
+
+    if (dailyCount >= 5) {
+      return { ok: false, error: 'too many requests in a day' };
+    }
+
+    const expiresAt = new Date(now.getTime() + 10 * 60 * 1000);
+    const token = this.generateVerificationCode();
+    const codeHash = this.hashCode(token);
+
+    const challenge = await this.prisma.authChallenge.create({
+      data: {
+        type: AuthChallengeType.EMAIL_VERIFY,
+        channel: MessagingChannel.EMAIL,
+        addressNorm: normalized,
+        addressRaw: params.email,
+        codeHash,
+        purpose: params.purpose ?? 'checkout',
+        expiresAt,
+      },
+    });
+
+    const sendResult = await this.emailService.sendVerificationEmail({
+      to: params.email,
+      token,
+      name: null,
+      locale: params.locale === 'zh' ? 'zh' : 'en',
+    });
+
+    await this.prisma.authChallenge.update({
+      where: { id: challenge.id },
+      data: { messagingSendId: sendResult.sendId },
+    });
+
+    return { ok: true };
+  }
+
+  async verifyCheckoutToken(params: {
+    email: string;
+    token: string;
+    purpose?: 'checkout';
+  }) {
+    const normalized = normalizeEmail(params.email);
+    const codeHash = this.hashCode(params.token.trim());
+    const now = new Date();
+
+    if (!normalized || !params.token.trim()) {
+      return { ok: false, error: 'email_or_token_empty' };
+    }
+
+    const record = await this.prisma.authChallenge.findFirst({
+      where: {
+        type: AuthChallengeType.EMAIL_VERIFY,
+        channel: MessagingChannel.EMAIL,
+        status: AuthChallengeStatus.PENDING,
+        addressNorm: normalized,
+        purpose: params.purpose ?? 'checkout',
+        codeHash,
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    if (!record) {
+      return { ok: false, error: 'token_not_found' };
+    }
+
+    if (record.expiresAt < now) {
+      await this.prisma.authChallenge.update({
+        where: { id: record.id },
+        data: { status: AuthChallengeStatus.EXPIRED, consumedAt: now },
+      });
+      return { ok: false, error: 'token_expired' };
+    }
+
+    await this.prisma.authChallenge.update({
+      where: { id: record.id },
+      data: { status: AuthChallengeStatus.CONSUMED, consumedAt: now },
+    });
+
+    return { ok: true, email: record.addressNorm };
+  }
+
   async verifyToken(token: string) {
     const codeHash = this.hashCode(token);
     const now = new Date();

--- a/apps/api/src/email/email.module.ts
+++ b/apps/api/src/email/email.module.ts
@@ -12,12 +12,16 @@ import { SendGridEmailProvider } from './providers/sendgrid-email.provider';
 import { SesEventProcessor } from './ses-event.processor';
 import type { EmailProvider } from './email.provider';
 import { SendGridEmailWebhookController } from './webhooks/sendgrid-email.webhook.controller';
+import { EmailCheckoutVerificationController } from './email-checkout-verification.controller';
 import { SendGridEmailWebhookService } from './webhooks/sendgrid-email.webhook.service';
 import { SendGridEmailWebhookVerifier } from './webhooks/sendgrid-email.webhook.verifier';
 
 @Module({
   imports: [HttpModule, PrismaModule, MessagingModule],
-  controllers: [SendGridEmailWebhookController],
+  controllers: [
+    SendGridEmailWebhookController,
+    EmailCheckoutVerificationController,
+  ],
   providers: [
     EmailService,
     EmailVerificationService,

--- a/apps/api/src/membership/membership.service.ts
+++ b/apps/api/src/membership/membership.service.ts
@@ -627,6 +627,8 @@ export class MembershipService {
       availableDiscountCents,
       marketingEmailOptIn: user.marketingEmailOptIn ?? false,
       phone: user.phone ?? null,
+      emailVerified: !!user.emailVerifiedAt,
+      emailVerifiedAt: user.emailVerifiedAt?.toISOString() ?? null,
       phoneVerified: !!user.phoneVerifiedAt,
       twoFactorEnabledAt: user.twoFactorEnabledAt,
       twoFactorMethod: user.twoFactorMethod,

--- a/apps/web/src/app/[locale]/checkout/page.tsx
+++ b/apps/web/src/app/[locale]/checkout/page.tsx
@@ -142,6 +142,8 @@ function isStandaloneWebApp(): boolean {
 
 const PHONE_OTP_REQUEST_URL = "/api/v1/auth/phone/send-code";
 const PHONE_OTP_VERIFY_URL = "/api/v1/auth/phone/verify-code";
+const EMAIL_OTP_REQUEST_URL = "/api/v1/email/checkout/send-code";
+const EMAIL_OTP_VERIFY_URL = "/api/v1/email/checkout/verify-code";
 const CHECKOUT_INTENT_STORAGE_KEY = "cloverCheckoutIntentId";
 const GOOGLE_PAY_INTENT_STORAGE_KEY = "sanq_google_pay_intent_v1";
 type DeliveryOptionDefinition = {
@@ -286,6 +288,8 @@ type MembershipSummaryResponse = {
   availableDiscountCents: number;
   recentOrders: unknown[];
   phoneVerified?: boolean;
+  emailVerified?: boolean;
+  emailVerifiedAt?: string | null;
 };
 
 type MembershipSummaryEnvelope =
@@ -758,6 +762,7 @@ export default function CheckoutPage() {
   // 会员手机号（从 membership 接口加载，用于预填）
   const [memberPhone, setMemberPhone] = useState<string | null>(null);
   const [memberPhoneVerified, setMemberPhoneVerified] = useState(false);
+  const [memberEmailVerified, setMemberEmailVerified] = useState(false);
   const [phonePrefilled, setPhonePrefilled] = useState(false); // 只预填一次
   const [memberFirstName, setMemberFirstName] = useState<string | null>(null);
   const [memberLastName, setMemberLastName] = useState<string | null>(null);
@@ -777,7 +782,10 @@ export default function CheckoutPage() {
     useState<Coordinates | null>(null);
   const [selectedPlaceId, setSelectedPlaceId] = useState<string | null>(null);
 
-  // 手机号验证流程状态
+  // 联系方式验证流程状态：邮箱优先，手机号兜底
+  const [contactVerificationMethod, setContactVerificationMethod] = useState<
+    "email" | "phone" | null
+  >(null);
   const [phoneVerificationStep, setPhoneVerificationStep] = useState<
     "idle" | "codeSent" | "verified"
   >("idle");
@@ -787,7 +795,8 @@ export default function CheckoutPage() {
   const [phoneVerificationError, setPhoneVerificationError] = useState<
     string | null
   >(null);
-  const [phoneVerified, setPhoneVerified] = useState(false); // ✅ 只有为 true 时才能下单
+  const [phoneVerified, setPhoneVerified] = useState(false);
+  const [emailVerified, setEmailVerified] = useState(false);
 
   const [confirmation, setConfirmation] = useState<ConfirmationState | null>(
     null,
@@ -1315,7 +1324,7 @@ export default function CheckoutPage() {
     customer.lastName.trim().length > 0 &&
     isEmailValid &&
     isValidCanadianPhone(customer.phone) &&
-    phoneVerified &&
+    (emailVerified || phoneVerified) &&
     (fulfillment === "pickup" || deliveryAddressReady) &&
     isStoreOpen &&
     !entitlementBlockingMessage;
@@ -1327,10 +1336,10 @@ export default function CheckoutPage() {
 
     if (!canPlaceOrder) {
       if (missingContactMessage) return missingContactMessage;
-      if (!phoneVerified) {
+      if (!emailVerified && !phoneVerified) {
         return locale === "zh"
-          ? "请先完成手机号验证。"
-          : "Please verify your phone number before placing the order.";
+          ? "请先完成邮箱或手机号验证。"
+          : "Please verify your email or phone number before placing the order.";
       }
       if (fulfillment === "delivery" && !deliveryAddressReady) {
         return locale === "zh"
@@ -1358,6 +1367,7 @@ export default function CheckoutPage() {
     isSubmitting,
     locale,
     missingContactMessage,
+    emailVerified,
     phoneVerified,
     storeStatusDetail,
   ]);
@@ -1719,6 +1729,28 @@ export default function CheckoutPage() {
       setSelectedAddressStableId(null);
     }
 
+    // 🔐 邮箱变更时，重置邮箱验证状态
+    if (field === "email") {
+      setPhoneVerificationError(null);
+      setPhoneVerificationCode("");
+      const trimmed = nextValue.trim().toLowerCase();
+      if (
+        memberEmail &&
+        memberEmailVerified &&
+        trimmed === memberEmail.toLowerCase()
+      ) {
+        setEmailVerified(true);
+        setContactVerificationMethod("email");
+        setPhoneVerificationStep("verified");
+        return;
+      }
+      setEmailVerified(false);
+      if (!phoneVerified) {
+        setContactVerificationMethod(null);
+        setPhoneVerificationStep("idle");
+      }
+    }
+
     // 🔐 手机号变更时，重置验证状态
     if (field === "phone") {
       setPhoneVerificationError(null);
@@ -1737,6 +1769,7 @@ export default function CheckoutPage() {
       if (memberPhone && memberPhoneVerified) {
         if (trimmed === memberPhone) {
           setPhoneVerified(true);
+          setContactVerificationMethod("phone");
           setPhoneVerificationStep("verified");
           return;
         }
@@ -1744,7 +1777,10 @@ export default function CheckoutPage() {
 
       // 其他情况：统一认为还未验证，需要走短信验证码
       setPhoneVerified(false);
-      setPhoneVerificationStep("idle");
+      if (!emailVerified) {
+        setContactVerificationMethod(null);
+        setPhoneVerificationStep("idle");
+      }
     }
   };
 
@@ -1795,34 +1831,49 @@ export default function CheckoutPage() {
     applySelectedAddress(selected, stableId);
   };
 
-  // 发送短信验证码
-  const handleSendPhoneCode = async () => {
-    if (!isValidCanadianPhone(customer.phone)) {
+  // 发送联系方式验证码：邮箱有效时优先邮箱，否则走手机号短信
+  const handleSendContactCode = async () => {
+    const useEmail = isEmailValid;
+    const usePhone = !useEmail && isValidCanadianPhone(customer.phone);
+
+    if (!useEmail && !usePhone) {
       setPhoneVerificationError(
         locale === "zh"
-          ? "请输入有效的加拿大手机号后再获取验证码。"
-          : "Please enter a valid Canadian phone number before requesting a code.",
+          ? "请先输入有效的邮箱；如不使用邮箱，请输入有效的加拿大手机号。"
+          : "Please enter a valid email first, or a valid Canadian phone number if you prefer SMS.",
       );
       return;
     }
 
-    const rawPhone = formatCanadianPhoneForApi(customer.phone);
     setPhoneVerificationLoading(true);
     setPhoneVerificationError(null);
+    setPhoneVerificationCode("");
 
     try {
-      const res = await fetch(PHONE_OTP_REQUEST_URL, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          phone: rawPhone,
-          purpose: "checkout", // 后端可按用途区分（可选）
-          locale,
-        }),
-      });
+      const res = await fetch(
+        useEmail ? EMAIL_OTP_REQUEST_URL : PHONE_OTP_REQUEST_URL,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(
+            useEmail
+              ? {
+                  email: customer.email.trim(),
+                  purpose: "checkout",
+                  locale,
+                }
+              : {
+                  phone: formatCanadianPhoneForApi(customer.phone),
+                  purpose: "checkout",
+                  locale,
+                },
+          ),
+        },
+      );
 
       await assertOperationResult(res);
 
+      setContactVerificationMethod(useEmail ? "email" : "phone");
       setPhoneVerificationStep("codeSent");
     } catch (err) {
       console.error("Unexpected checkout error", toSafeErrorLog(err));
@@ -1833,8 +1884,8 @@ export default function CheckoutPage() {
       setPhoneVerificationError(
         isDailyLimitReached
           ? locale === "zh"
-            ? "今日验证码发送次数已达上限，请更换手机号再试。"
-            : "Daily verification code request limit reached. Please try again with another phone number."
+            ? "今日验证码发送次数已达上限，请更换联系方式再试。"
+            : "Daily verification code request limit reached. Please try another contact method."
           : locale === "zh"
             ? "验证码发送失败，请稍后重试。"
             : "Failed to send verification code. Please try again.",
@@ -1844,36 +1895,60 @@ export default function CheckoutPage() {
     }
   };
 
-  // 校验短信验证码
-  const handleVerifyPhoneCode = async () => {
+  // 校验联系方式验证码
+  const handleVerifyContactCode = async () => {
     if (!phoneVerificationCode.trim()) {
       setPhoneVerificationError(
         locale === "zh"
-          ? "请输入短信验证码。"
+          ? "请输入验证码。"
           : "Please enter the verification code.",
       );
       return;
     }
 
-    const rawPhone = formatCanadianPhoneForApi(customer.phone);
+    if (!contactVerificationMethod) {
+      setPhoneVerificationError(
+        locale === "zh"
+          ? "请先获取验证码。"
+          : "Please request a verification code first.",
+      );
+      return;
+    }
+
     setPhoneVerificationLoading(true);
     setPhoneVerificationError(null);
 
     try {
-      const res = await fetch(PHONE_OTP_VERIFY_URL, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          phone: rawPhone,
-          code: phoneVerificationCode.trim(),
-          purpose: "checkout",
-        }),
-      });
+      const res = await fetch(
+        contactVerificationMethod === "email"
+          ? EMAIL_OTP_VERIFY_URL
+          : PHONE_OTP_VERIFY_URL,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(
+            contactVerificationMethod === "email"
+              ? {
+                  email: customer.email.trim(),
+                  code: phoneVerificationCode.trim(),
+                  purpose: "checkout",
+                }
+              : {
+                  phone: formatCanadianPhoneForApi(customer.phone),
+                  code: phoneVerificationCode.trim(),
+                  purpose: "checkout",
+                },
+          ),
+        },
+      );
 
       await assertOperationResult(res);
 
-      // ✅ 验证成功：允许下单
-      setPhoneVerified(true);
+      if (contactVerificationMethod === "email") {
+        setEmailVerified(true);
+      } else {
+        setPhoneVerified(true);
+      }
       setPhoneVerificationStep("verified");
     } catch (err) {
       console.error("Unexpected checkout error", toSafeErrorLog(err));
@@ -1882,7 +1957,11 @@ export default function CheckoutPage() {
           ? "验证码验证失败，请检查后重试。"
           : "Verification failed. Please check the code and try again.",
       );
-      setPhoneVerified(false);
+      if (contactVerificationMethod === "email") {
+        setEmailVerified(false);
+      } else {
+        setPhoneVerified(false);
+      }
     } finally {
       setPhoneVerificationLoading(false);
     }
@@ -1966,6 +2045,7 @@ export default function CheckoutPage() {
       setAvailableCoupons([]);
       setMemberPhone(null);
       setMemberPhoneVerified(false);
+      setMemberEmailVerified(false);
       setMemberFirstName(null);
       setMemberLastName(null);
       setMemberEmail(null);
@@ -1985,6 +2065,7 @@ export default function CheckoutPage() {
       setAvailableCoupons([]);
       setMemberPhone(null);
       setMemberPhoneVerified(false);
+      setMemberEmailVerified(false);
       setMemberUserStableId(null);
       setMemberFirstName(null);
       setMemberLastName(null);
@@ -2029,6 +2110,7 @@ export default function CheckoutPage() {
           data.phone ? stripCanadianCountryCode(data.phone) : null,
         );
         setMemberPhoneVerified(!!data.phoneVerified);
+        setMemberEmailVerified(!!data.emailVerified || !!data.emailVerifiedAt);
         const fallbackName = data.displayName ?? "";
         const fallbackParts = fallbackName.trim()
           ? fallbackName.trim().split(/\s+/)
@@ -2053,6 +2135,7 @@ export default function CheckoutPage() {
         );
         setLoyaltyInfo(null);
         setMemberPhone(null);
+        setMemberEmailVerified(false);
         setMemberUserStableId(null);
       } finally {
         setLoyaltyLoading(false);
@@ -2185,7 +2268,7 @@ export default function CheckoutPage() {
   // 用会员手机号预填结算电话：只填一次，且用户没自己输入时才填
   useEffect(() => {
     if (phonePrefilled) return;
-    if (!memberPhone) return;
+    if (!memberPhone || memberEmail) return;
 
     setCustomer((prev) => {
       if (prev.phone && prev.phone.trim().length > 0) {
@@ -2195,7 +2278,7 @@ export default function CheckoutPage() {
     });
 
     setPhonePrefilled(true);
-  }, [memberPhone, phonePrefilled]);
+  }, [memberEmail, memberPhone, phonePrefilled]);
 
   useEffect(() => {
     if (firstNamePrefilled) return;
@@ -2236,8 +2319,15 @@ export default function CheckoutPage() {
       return { ...prev, email: memberEmail };
     });
 
+    if (memberEmailVerified) {
+      setEmailVerified(true);
+      setContactVerificationMethod("email");
+      setPhoneVerificationStep("verified");
+      setPhoneVerificationError(null);
+    }
+
     setEmailPrefilled(true);
-  }, [emailPrefilled, memberEmail]);
+  }, [emailPrefilled, memberEmail, memberEmailVerified]);
 
   useEffect(() => {
     if (addressPrefilled) return;
@@ -2266,16 +2356,38 @@ export default function CheckoutPage() {
     memberAddresses,
   ]);
 
-  // ✅ 如果当前手机号与会员账号中的手机号一致，就自动视为“已验证”
+  // ✅ 优先用会员已验证邮箱自动绕过；否则再用会员已验证手机号绕过
   useEffect(() => {
-    if (!memberPhone || !memberPhoneVerified) return;
+    if (
+      memberEmail &&
+      memberEmailVerified &&
+      customer.email.trim().toLowerCase() === memberEmail.toLowerCase()
+    ) {
+      setEmailVerified(true);
+      setContactVerificationMethod("email");
+      setPhoneVerificationStep("verified");
+      setPhoneVerificationError(null);
+      return;
+    }
 
-    if (customer.phone && customer.phone === memberPhone) {
+    if (
+      memberPhone &&
+      memberPhoneVerified &&
+      customer.phone === memberPhone
+    ) {
       setPhoneVerified(true);
+      setContactVerificationMethod("phone");
       setPhoneVerificationStep("verified");
       setPhoneVerificationError(null);
     }
-  }, [memberPhone, memberPhoneVerified, customer.phone]);
+  }, [
+    memberEmail,
+    memberEmailVerified,
+    memberPhone,
+    memberPhoneVerified,
+    customer.email,
+    customer.phone,
+  ]);
 
   // 带可选 override 类型的距离校验
   const validateDeliveryDistance = useCallback(async () => {
@@ -3123,7 +3235,14 @@ export default function CheckoutPage() {
                 ) : null}
 
                 <label className="block text-xs font-medium text-slate-600">
-                  {strings.contactFields.phone}
+                  {locale === "zh"
+                    ? "邮箱或手机号验证"
+                    : "Email or phone verification"}
+                  <p className="mt-1 text-[11px] font-normal text-slate-500">
+                    {locale === "zh"
+                      ? "优先使用邮箱验证，也可使用手机号验证。"
+                      : "Email verification is preferred; phone verification is also available."}
+                  </p>
                   <div className="mt-1 flex flex-col gap-2 sm:flex-row sm:items-center">
                     <div className="flex w-full items-center rounded-2xl border border-slate-200 bg-white p-2 text-sm text-slate-700 focus-within:ring-1 focus-within:ring-slate-400">
                       <span className="mr-2 text-xs text-slate-500">+1</span>
@@ -3138,17 +3257,24 @@ export default function CheckoutPage() {
                       />
                     </div>
                     <div className="flex items-center gap-2">
-                      {phoneVerified ? (
+                      {emailVerified || phoneVerified ? (
                         <span className="inline-flex items-center rounded-full bg-emerald-50 px-3 py-1 text-[11px] font-medium text-emerald-700">
-                          {locale === "zh" ? "手机号已验证" : "Phone verified"}
+                          {emailVerified
+                            ? locale === "zh"
+                              ? "邮箱已验证"
+                              : "Email verified"
+                            : locale === "zh"
+                              ? "手机号已验证"
+                              : "Phone verified"}
                         </span>
                       ) : (
                         <button
                           type="button"
-                          onClick={handleSendPhoneCode}
+                          onClick={handleSendContactCode}
                           disabled={
                             phoneVerificationLoading ||
-                            !isValidCanadianPhone(customer.phone)
+                            (!isEmailValid &&
+                              !isValidCanadianPhone(customer.phone))
                           }
                           className="shrink-0 rounded-full border border-slate-300 px-3 py-1 text-[11px] font-medium text-slate-600 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60"
                         >
@@ -3164,7 +3290,9 @@ export default function CheckoutPage() {
                     </div>
                   </div>
 
-                  {!phoneVerified && phoneVerificationStep === "codeSent" && (
+                  {!emailVerified &&
+                    !phoneVerified &&
+                    phoneVerificationStep === "codeSent" && (
                     <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-center">
                       <input
                         value={phoneVerificationCode}
@@ -3172,15 +3300,19 @@ export default function CheckoutPage() {
                           setPhoneVerificationCode(e.target.value)
                         }
                         placeholder={
-                          locale === "zh"
-                            ? "请输入短信验证码"
-                            : "Enter SMS code"
+                          contactVerificationMethod === "email"
+                            ? locale === "zh"
+                              ? "请输入邮箱验证码"
+                              : "Enter email code"
+                            : locale === "zh"
+                              ? "请输入短信验证码"
+                              : "Enter SMS code"
                         }
                         className="w-full rounded-2xl border border-slate-200 bg-white p-2 text-sm text-slate-700 focus:border-slate-400 focus:outline-none"
                       />
                       <button
                         type="button"
-                        onClick={handleVerifyPhoneCode}
+                        onClick={handleVerifyContactCode}
                         disabled={phoneVerificationLoading}
                         className="shrink-0 rounded-full bg-slate-900 px-3 py-1 text-[11px] font-medium text-white hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60"
                       >
@@ -3189,8 +3321,12 @@ export default function CheckoutPage() {
                             ? "验证中…"
                             : "Verifying…"
                           : locale === "zh"
-                            ? "验证手机号"
-                            : "Verify phone"}
+                            ? contactVerificationMethod === "email"
+                              ? "验证邮箱"
+                              : "验证手机号"
+                            : contactVerificationMethod === "email"
+                              ? "Verify email"
+                              : "Verify phone"}
                       </button>
                     </div>
                   )}
@@ -3201,11 +3337,11 @@ export default function CheckoutPage() {
                     </p>
                   )}
 
-                  {!phoneVerified && !phoneVerificationError && (
+                  {!emailVerified && !phoneVerified && !phoneVerificationError && (
                     <p className="mt-1 text-[11px] text-slate-500">
                       {locale === "zh"
-                        ? "为保障订单通知及外送沟通，请先验证手机号后再提交订单。"
-                        : "Please verify your phone number before placing the order so we can contact you if needed."}
+                        ? "为保障订单通知及外送沟通，请先完成邮箱或手机号验证后再提交订单。"
+                        : "Please verify your email or phone number before placing the order so we can contact you if needed."}
                     </p>
                   )}
                 </label>


### PR DESCRIPTION
### Motivation
- 将结算页联系方式验证从仅依赖手机号扩展为“邮箱或手机号”，并优先使用邮箱验证以提升用户体验和通知可靠性。
- 在会员预填与绕过逻辑中优先考虑已验证邮箱，确保会员已验证邮箱能直接绕过验证码流程并减少重复验证。
- 为无邮箱的场景保留手机号验证码兜底，同时确保所有支付/提交路径受新的联系方式验证状态控制。

### Description
- 前端：在 `apps/web/src/app/[locale]/checkout/page.tsx` 添加邮箱 OTP 接口常量 `EMAIL_OTP_REQUEST_URL` / `EMAIL_OTP_VERIFY_URL`，新增状态 `emailVerified`、`memberEmailVerified` 和 `contactVerificationMethod`，并把 `canPlaceOrder` 改为依赖 `(emailVerified || phoneVerified)`，同时将错误提示改为邮箱优先的文案。
- 前端：将短信验证码流程抽象为联系方式验证码流程，新增 `handleSendContactCode` 与 `handleVerifyContactCode`，当邮箱有效时优先调用邮箱 checkout OTP 接口，否则回退到手机号 OTP，并在验证成功后分别设置 `emailVerified` 或 `phoneVerified`。
- 前端：改写会员预填与绕过逻辑：优先从会员摘要预填邮箱并在 `memberEmailVerified` 且与页面邮箱一致时直接标记 `emailVerified` 绕过验证码；仅在会员无邮箱时才使用会员手机号预填与绕过逻辑。
- 后端：新增 checkout-scoped 邮箱 OTP 控制器 `apps/api/src/email/email-checkout-verification.controller.ts` 并在 `EmailModule` 中注册；在 `EmailVerificationService` 中新增 `requestCheckoutVerification` 与 `verifyCheckoutToken`（`purpose: 'checkout'`），实现发送与校验邮箱验证码的 DB/challenge 流程。
- 后端：扩展会员摘要返回字段，新增 `emailVerified` 与 `emailVerifiedAt`（在 `apps/api/src/membership/membership.service.ts`），供前端按顺序判断：会员邮箱一致且已验证 → 绕过；否则会员手机号一致且已验证 → 绕过；否则要求验证码。

### Testing
- 已运行 `git diff --check` 并修复格式化问题，结果通过。
- 已运行 `pnpm --filter web lint`，结果通过无 ESLint 错误。
- 已运行 `pnpm --filter api lint`，结果通过（包含 `prisma generate` 及 ESLint 检查）。
- 已执行 `pnpm --filter api build` 与 `pnpm --filter web build`，两次构建均成功且前端类型/构建检查通过。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54153ab3408327ab12974c6f215834)